### PR TITLE
Fix: missing interface for custom signer and verifier

### DIFF
--- a/examples/all.ts
+++ b/examples/all.ts
@@ -47,12 +47,12 @@ export const createKeyPair = () => {
 
   // Issue a signed JWT credential with the specified claims and disclosures
   // Return a Encoded SD JWT. Issuer send the credential to the holder
-  const credential = await sdjwt.issue(claims, privateKey, disclosureFrame);
+  const credential = await sdjwt.issue(claims, { privateKey }, disclosureFrame);
   console.log('encodedJwt:', credential);
 
   // Holder Receive the credential from the issuer and validate it
   // Return a boolean result
-  const validated = await sdjwt.validate(credential, publicKey);
+  const validated = await sdjwt.validate(credential, { publicKey });
   console.log('validated:', validated);
 
   // You can decode the SD JWT to get the payload and the disclosures
@@ -94,6 +94,10 @@ export const createKeyPair = () => {
 
   // Verify the presentation using the public key and the required claims
   // return a boolean result
-  const verified = await sdjwt.verify(credential, publicKey, requiredClaims);
+  const verified = await sdjwt.verify(
+    credential,
+    { publicKey },
+    requiredClaims,
+  );
   console.log('verified:', verified);
 })();

--- a/examples/basic.ts
+++ b/examples/basic.ts
@@ -23,11 +23,11 @@ export const createKeyPair = () => {
 
   // Issue a signed JWT credential with the specified claims and disclosures
   // Return a Encoded SD JWT. Issuer send the credential to the holder
-  const credential = await sdjwt.issue(claims, privateKey, disclosureFrame);
+  const credential = await sdjwt.issue(claims, { privateKey }, disclosureFrame);
 
   // Holder Receive the credential from the issuer and validate it
   // Return a boolean result
-  const valid = await sdjwt.validate(credential, publicKey);
+  const valid = await sdjwt.validate(credential, { publicKey });
 
   // Holder Define the presentation frame to specify which claims should be presented
   // The list of presented claims must be a subset of the disclosed claims
@@ -43,6 +43,10 @@ export const createKeyPair = () => {
 
   // Verify the presentation using the public key and the required claims
   // return a boolean result
-  const verified = await sdjwt.verify(presentation, publicKey, requiredClaims);
+  const verified = await sdjwt.verify(
+    presentation,
+    { publicKey },
+    requiredClaims,
+  );
   console.log(verified);
 })();

--- a/examples/custom.ts
+++ b/examples/custom.ts
@@ -44,14 +44,14 @@ export const createKeyPair = () => {
   // Return a Encoded SD JWT. Issuer send the credential to the holder
   const credential = await SDJwtInstance.issue(
     claims,
-    privateKey,
+    { privateKey },
     disclosureFrame,
   );
   console.log('encodedJwt:', credential);
 
   // Holder Receive the credential from the issuer and validate it
   // Return a boolean result
-  const validated = await SDJwtInstance.validate(credential, publicKey);
+  const validated = await SDJwtInstance.validate(credential, { publicKey });
   console.log('validated:', validated);
 
   // You can decode the SD JWT to get the payload and the disclosures
@@ -98,7 +98,7 @@ export const createKeyPair = () => {
   // return a boolean result
   const verified = await SDJwtInstance.verify(
     presentation,
-    publicKey,
+    { publicKey },
     requiredClaims,
   );
   console.log('verified:', verified);

--- a/examples/custom_header.ts
+++ b/examples/custom_header.ts
@@ -23,9 +23,14 @@ export const createKeyPair = () => {
 
   // Issue a signed JWT credential with the specified claims and disclosures
   // Return a Encoded SD JWT. Issuer send the credential to the holder
-  const credential = await sdjwt.issue(claims, privateKey, disclosureFrame, {
-    header: { typ: 'vc+sd-jwt', custom: 'data' }, // You can add custom header data to the SD JWT
-  });
+  const credential = await sdjwt.issue(
+    claims,
+    { privateKey },
+    disclosureFrame,
+    {
+      header: { typ: 'vc+sd-jwt', custom: 'data' }, // You can add custom header data to the SD JWT
+    },
+  );
   console.log('encodedSdjwt:', credential);
 
   // You can check the custom header data by decoding the SD JWT

--- a/examples/decoy.ts
+++ b/examples/decoy.ts
@@ -20,7 +20,7 @@ export const createKeyPair = () => {
     _sd: ['id'],
     _sd_decoy: 1, // 1 decoy digest will be added in SD JWT
   };
-  const credential = await sdjwt.issue(claims, privateKey, disclosureFrame);
+  const credential = await sdjwt.issue(claims, { privateKey }, disclosureFrame);
   console.log('encodedSdjwt:', credential);
 
   // You can check the decoy digest in the SD JWT by decoding it

--- a/examples/kb.ts
+++ b/examples/kb.ts
@@ -26,7 +26,11 @@ export const createKeyPair = () => {
     sd_hash: '1234',
   };
 
-  const encodedSdjwt = await sdjwt.issue(claims, privateKey, disclosureFrame);
+  const encodedSdjwt = await sdjwt.issue(
+    claims,
+    { privateKey },
+    disclosureFrame,
+  );
   console.log('encodedSdjwt:', encodedSdjwt);
   const sdjwttoken = sdjwt.decode(encodedSdjwt);
   console.log(sdjwttoken);
@@ -41,7 +45,7 @@ export const createKeyPair = () => {
 
   const verified = await sdjwt.verify(
     presentedSdJwt,
-    publicKey,
+    { publicKey },
     ['id', 'ssn'],
     {
       kb: {

--- a/examples/sdjwtobject.ts
+++ b/examples/sdjwtobject.ts
@@ -24,7 +24,7 @@ export const createKeyPair = () => {
 
   // Issue a signed JWT credential with the specified claims and disclosures
   // Return a Encoded SD JWT. Issuer send the credential to the holder
-  const credential = await sdjwt.issue(claims, privateKey, disclosureFrame);
+  const credential = await sdjwt.issue(claims, { privateKey }, disclosureFrame);
   console.log('encodedSdjwt:', credential);
 
   // You can decode the SD JWT to get the payload and the disclosures

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hopae/sd-jwt",
-  "version": "2.1.0",
+  "version": "2.0.1",
   "description": "sd-jwt draft 7 implementation in typescript",
   "main": "dist/index.js",
   "browser": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hopae/sd-jwt",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "sd-jwt draft 7 implementation in typescript",
   "main": "dist/index.js",
   "browser": {

--- a/src/test/index.spec.ts
+++ b/src/test/index.spec.ts
@@ -15,7 +15,7 @@ describe('index', () => {
       {
         foo: 'bar',
       },
-      privateKey,
+      { privateKey },
       {
         _sd: ['foo'],
       },
@@ -49,7 +49,7 @@ describe('index', () => {
       {
         foo: 'bar',
       },
-      privateKey,
+      { privateKey },
       {
         _sd: ['foo'],
       },
@@ -73,13 +73,54 @@ describe('index', () => {
     expect(presentation).toBeDefined();
   });
 
+  test('issue with signer', async () => {
+    const { privateKey } = Crypto.generateKeyPairSync('ed25519');
+    const testSigner: Signer = async (data: string) => {
+      const sig = Crypto.sign(null, Buffer.from(data), privateKey);
+      return Buffer.from(sig).toString('base64url');
+    };
+    const credential = await sdjwt.issue(
+      {
+        foo: 'bar',
+      },
+      { signer: testSigner },
+      {
+        _sd: ['foo'],
+      },
+    );
+
+    expect(credential).toBeDefined();
+  });
+
+  test('issue with signer in config', async () => {
+    const { privateKey } = Crypto.generateKeyPairSync('ed25519');
+    const testSigner: Signer = async (data: string) => {
+      const sig = Crypto.sign(null, Buffer.from(data), privateKey);
+      return Buffer.from(sig).toString('base64url');
+    };
+    const SDJwtInstance = sdjwt.create({
+      signer: testSigner,
+    });
+    const credential = await SDJwtInstance.issue(
+      {
+        foo: 'bar',
+      },
+      undefined,
+      {
+        _sd: ['foo'],
+      },
+    );
+
+    expect(credential).toBeDefined();
+  });
+
   test('verify failed', async () => {
     const { privateKey, publicKey } = Crypto.generateKeyPairSync('ed25519');
     const credential = await sdjwt.issue(
       {
         foo: 'bar',
       },
-      privateKey,
+      { privateKey },
       {
         _sd: ['foo'],
       },
@@ -101,7 +142,7 @@ describe('index', () => {
       {
         foo: 'bar',
       },
-      privateKey,
+      { privateKey },
       {
         _sd: ['foo'],
       },

--- a/src/type.ts
+++ b/src/type.ts
@@ -19,6 +19,10 @@ export type SDJWTConfig = {
   verifier?: Verifier | null;
 };
 
+export type SignOptions =
+  | { privateKey: Uint8Array | KeyLike }
+  | { signer: Signer };
+
 export type kbHeader = { typ: 'kb+jwt'; alg: string };
 export type kbPayload = {
   iat: number;

--- a/src/type.ts
+++ b/src/type.ts
@@ -23,6 +23,10 @@ export type SignOptions =
   | { privateKey: Uint8Array | KeyLike }
   | { signer: Signer };
 
+export type VerifyOptions =
+  | { publicKey: Uint8Array | KeyLike }
+  | { verifier: Verifier };
+
 export type kbHeader = { typ: 'kb+jwt'; alg: string };
 export type kbPayload = {
   iat: number;

--- a/test/app-e2e.spec.ts
+++ b/test/app-e2e.spec.ts
@@ -50,7 +50,7 @@ describe('App', () => {
       disclosureFrame,
     );
     expect(encodedSdjwt).toBeDefined();
-    const validated = await sdjwt.validate(encodedSdjwt, publicKey);
+    const validated = await sdjwt.validate(encodedSdjwt, { publicKey });
     expect(validated).toBeDefined();
 
     const decoded = sdjwt.decode(encodedSdjwt);
@@ -103,7 +103,7 @@ describe('App', () => {
     const requiredClaimKeys = ['firstname', 'id', 'data.ssn'];
     const verified = await sdjwt.verify(
       encodedSdjwt,
-      publicKey,
+      { publicKey },
       requiredClaimKeys,
     );
     expect(verified).toBeDefined();
@@ -186,7 +186,7 @@ async function JSONtest(filename: string) {
 
   expect(encodedSdjwt).toBeDefined();
 
-  const validated = await sdjwt.validate(encodedSdjwt, publicKey);
+  const validated = await sdjwt.validate(encodedSdjwt, { publicKey });
 
   expect(validated).toBeDefined();
   expect(validated).toStrictEqual({
@@ -207,7 +207,7 @@ async function JSONtest(filename: string) {
 
   const verified = await sdjwt.verify(
     encodedSdjwt,
-    publicKey,
+    { publicKey },
     test.requiredClaimKeys,
   );
 

--- a/test/app-e2e.spec.ts
+++ b/test/app-e2e.spec.ts
@@ -44,7 +44,11 @@ describe('App', () => {
         _sd: ['hi'],
       },
     };
-    const encodedSdjwt = await sdjwt.issue(claims, privateKey, disclosureFrame);
+    const encodedSdjwt = await sdjwt.issue(
+      claims,
+      { privateKey },
+      disclosureFrame,
+    );
     expect(encodedSdjwt).toBeDefined();
     const validated = await sdjwt.validate(encodedSdjwt, publicKey);
     expect(validated).toBeDefined();
@@ -176,7 +180,7 @@ async function JSONtest(filename: string) {
 
   const encodedSdjwt = await sdjwt.issue(
     test.claims,
-    privateKey,
+    { privateKey },
     test.disclosureFrame,
   );
 


### PR DESCRIPTION
I fixed missing interface for custom signer and verifier.

Examples are applied.

update version to 2.0.1