### PR TITLE
Add sync functions for decode/present

### DIFF
--- a/packages/decode/src/test/decode.spec.ts
+++ b/packages/decode/src/test/decode.spec.ts
@@ -1,5 +1,12 @@
 import { describe, expect, test } from 'vitest';
-import { decodeJwt, decodeSdJwt, getClaims, splitSdJwt } from '../decode';
+import {
+  decodeJwt,
+  decodeSdJwt,
+  decodeSdJwtSync,
+  getClaims,
+  getClaimsSync,
+  splitSdJwt,
+} from '../decode';
 import { digest } from '@hopae/sd-jwt-node-crypto';
 
 describe('decode tests', () => {
@@ -57,6 +64,26 @@ describe('decode tests', () => {
     expect(decodedSdJwt.jwt).toBeDefined();
   });
 
+  test('decode sdjwt sync', () => {
+    const sdjwt =
+      'eyJ0eXAiOiJzZC1qd3QiLCJhbGciOiJFZERTQSJ9.eyJfc2QiOlsiaWQ1azZ1ZVplVTY4bExaMlU2YjJJbF9QR3ZKb1RDMlpkMkpwY0RwMzFIWSJdLCJfc2RfYWxnIjoic2hhLTI1NiJ9.GiLF_HhacrstqCJ223VvWOoJJWU8qk4dYQHklSMwxv36pPF_7ER53Wbty1qYRlQ6NeMUdBRRdj9JQLLCzz1gCQ~WyI2NTMxNDA2ZmVhZmU0YjBmIiwiZm9vIiwiYmFyIl0~';
+    const decodedSdJwt = decodeSdJwtSync(sdjwt, digest);
+    expect(decodedSdJwt).toBeDefined();
+    expect(decodedSdJwt.kbJwt).toBeUndefined();
+    expect(decodedSdJwt.disclosures.length).toEqual(1);
+    expect(decodedSdJwt.jwt).toBeDefined();
+  });
+
+  test('decode jwt sync', () => {
+    const jwt =
+      'eyJhbGciOiJIUzI1NiIsInR5cCI6InNkK2p3dCJ9.eyJsYXN0bmFtZSI6IkRvZSIsInNzbiI6IjEyMy00NS02Nzg5IiwiX3NkIjpbIk4yUXhZV1UxTlRnME1qQmpOR1JpWVRCaU1tRmtaamN5WXpSbFpXUmhaRGd5WkRCbE1qaGhZVGcwTnpJMU9XSXpZek5qWkdNNE1qZG1NVGN6TmpZd05RIiwiWlRSalkyUTVOemRoWkRVM05tWTFZV0UyTmpka01XVmpNRE16WXpOak5qQmtNak5pT0dZelpHSTBOelV4TURsak9EWTRNREEzWm1JeFpUY3daREZqTmciXSwiX3NkX2FsZyI6InNoYS0yNTYifQ.mX14Sw86xy8NFQta7tCfNmhVCqzfaJ_K3VEIhTjbLDY';
+    const decodedSdJwt = decodeSdJwtSync(jwt, digest);
+    expect(decodedSdJwt).toBeDefined();
+    expect(decodedSdJwt.kbJwt).toBeUndefined();
+    expect(decodedSdJwt.disclosures.length).toEqual(0);
+    expect(decodedSdJwt.jwt).toBeDefined();
+  });
+
   test('get claims', async () => {
     const sdjwt =
       'eyJ0eXAiOiJzZC1qd3QiLCJhbGciOiJFZERTQSJ9.eyJfc2QiOlsiaWQ1azZ1ZVplVTY4bExaMlU2YjJJbF9QR3ZKb1RDMlpkMkpwY0RwMzFIWSJdLCJfc2RfYWxnIjoic2hhLTI1NiJ9.GiLF_HhacrstqCJ223VvWOoJJWU8qk4dYQHklSMwxv36pPF_7ER53Wbty1qYRlQ6NeMUdBRRdj9JQLLCzz1gCQ~WyI2NTMxNDA2ZmVhZmU0YjBmIiwiZm9vIiwiYmFyIl0~';
@@ -76,6 +103,38 @@ describe('decode tests', () => {
       'eyJ0eXAiOiJzZC1qd3QiLCJhbGciOiJFZERTQSJ9.eyJ0ZXN0Ijp7Il9zZCI6WyJqVEszMHNleDZhYV9kUk1KSWZDR056Q0FwbVB5MzRRNjNBa3QzS3hhSktzIl19LCJfc2QiOlsiME9nMi1ReG95eW1UOGNnVzZZUjVSSFpQLUJuR2tHUi1NM2otLV92RWlzSSIsIkcwZ3lHNnExVFMyUlQxMkZ3X2RRRDVVcjlZc1AwZlVWOXVtQWdGMC1jQ1EiXSwiX3NkX2FsZyI6InNoYS0yNTYifQ.ggEyE4SeDO2Hu3tol3VLmi7NQj56yKzKQDaafocgkLrUBdivghohtzrfcbrMN7CRufJ_Cnh0EL54kymXLGTdDQ~WyIwNGU0MjAzOWU4ZWFiOWRjIiwiYSIsIjEiXQ~WyIwOGE1Yjc5MjMyYjAzYzBhIiwiMSJd~WyJiNWE2YjUzZGQwYTFmMGIwIiwienp6IiwieHh4Il0~WyIxYzdmOTE4ZTE0MjA2NzZiIiwiZm9vIiwiYmFyIl0~WyJmZjYxYzQ5ZGU2NjFiYzMxIiwiYXJyIixbeyIuLi4iOiJTSG96VW5KNUpkd0ZtTjVCbXB5dXZCWGZfZWRjckVvcExPYThTVlBFUmg0In0sIjIiLHsiX3NkIjpbIkpuODNhZkp0OGx4NG1FMzZpRkZyS2U2R2VnN0dlVUQ4Z3UwdVo3NnRZcW8iXX1dXQ~';
     const decodedSdJwt = await decodeSdJwt(sdjwt, digest);
     const claims = await getClaims(
+      decodedSdJwt.jwt.payload,
+      decodedSdJwt.disclosures,
+      digest,
+    );
+    expect(claims).toStrictEqual({
+      foo: 'bar',
+      arr: ['1', '2', { a: '1' }],
+      test: {
+        zzz: 'xxx',
+      },
+    });
+  });
+
+  test('get claims sync', () => {
+    const sdjwt =
+      'eyJ0eXAiOiJzZC1qd3QiLCJhbGciOiJFZERTQSJ9.eyJfc2QiOlsiaWQ1azZ1ZVplVTY4bExaMlU2YjJJbF9QR3ZKb1RDMlpkMkpwY0RwMzFIWSJdLCJfc2RfYWxnIjoic2hhLTI1NiJ9.GiLF_HhacrstqCJ223VvWOoJJWU8qk4dYQHklSMwxv36pPF_7ER53Wbty1qYRlQ6NeMUdBRRdj9JQLLCzz1gCQ~WyI2NTMxNDA2ZmVhZmU0YjBmIiwiZm9vIiwiYmFyIl0~';
+    const decodedSdJwt = decodeSdJwtSync(sdjwt, digest);
+    const claims = getClaimsSync(
+      decodedSdJwt.jwt.payload,
+      decodedSdJwt.disclosures,
+      digest,
+    );
+    expect(claims).toStrictEqual({
+      foo: 'bar',
+    });
+  });
+
+  test('getClaims sync #2', () => {
+    const sdjwt =
+      'eyJ0eXAiOiJzZC1qd3QiLCJhbGciOiJFZERTQSJ9.eyJ0ZXN0Ijp7Il9zZCI6WyJqVEszMHNleDZhYV9kUk1KSWZDR056Q0FwbVB5MzRRNjNBa3QzS3hhSktzIl19LCJfc2QiOlsiME9nMi1ReG95eW1UOGNnVzZZUjVSSFpQLUJuR2tHUi1NM2otLV92RWlzSSIsIkcwZ3lHNnExVFMyUlQxMkZ3X2RRRDVVcjlZc1AwZlVWOXVtQWdGMC1jQ1EiXSwiX3NkX2FsZyI6InNoYS0yNTYifQ.ggEyE4SeDO2Hu3tol3VLmi7NQj56yKzKQDaafocgkLrUBdivghohtzrfcbrMN7CRufJ_Cnh0EL54kymXLGTdDQ~WyIwNGU0MjAzOWU4ZWFiOWRjIiwiYSIsIjEiXQ~WyIwOGE1Yjc5MjMyYjAzYzBhIiwiMSJd~WyJiNWE2YjUzZGQwYTFmMGIwIiwienp6IiwieHh4Il0~WyIxYzdmOTE4ZTE0MjA2NzZiIiwiZm9vIiwiYmFyIl0~WyJmZjYxYzQ5ZGU2NjFiYzMxIiwiYXJyIixbeyIuLi4iOiJTSG96VW5KNUpkd0ZtTjVCbXB5dXZCWGZfZWRjckVvcExPYThTVlBFUmg0In0sIjIiLHsiX3NkIjpbIkpuODNhZkp0OGx4NG1FMzZpRkZyS2U2R2VnN0dlVUQ4Z3UwdVo3NnRZcW8iXX1dXQ~';
+    const decodedSdJwt = decodeSdJwtSync(sdjwt, digest);
+    const claims = getClaimsSync(
       decodedSdJwt.jwt.payload,
       decodedSdJwt.disclosures,
       digest,

--- a/packages/node-crypto/src/crypto.ts
+++ b/packages/node-crypto/src/crypto.ts
@@ -9,10 +9,10 @@ export const generateSalt = (length: number): string => {
   return salt.substring(0, length);
 };
 
-export const digest = async (
+export const digest = (
   data: string,
   algorithm: string = 'SHA-256',
-): Promise<Uint8Array> => {
+): Uint8Array => {
   const nodeAlg = toNodeCryptoAlg(algorithm);
   const hash = createHash(nodeAlg);
   hash.update(data);

--- a/packages/present/src/test/present.spec.ts
+++ b/packages/present/src/test/present.spec.ts
@@ -1,7 +1,12 @@
 import { describe, expect, test } from 'vitest';
 import { digest } from '@hopae/sd-jwt-node-crypto';
-import { present, presentableKeys } from '../present';
-import { decodeSdJwt } from '@hopae/sd-jwt-decode';
+import {
+  present,
+  presentSync,
+  presentableKeys,
+  presentableKeysSync,
+} from '../present';
+import { decodeSdJwt, decodeSdJwtSync } from '@hopae/sd-jwt-decode';
 
 describe('Present tests', () => {
   test('presentableKeys', async () => {
@@ -9,6 +14,18 @@ describe('Present tests', () => {
       'eyJ0eXAiOiJzZC1qd3QiLCJhbGciOiJFZERTQSJ9.eyJ0ZXN0Ijp7Il9zZCI6WyJqVEszMHNleDZhYV9kUk1KSWZDR056Q0FwbVB5MzRRNjNBa3QzS3hhSktzIl19LCJfc2QiOlsiME9nMi1ReG95eW1UOGNnVzZZUjVSSFpQLUJuR2tHUi1NM2otLV92RWlzSSIsIkcwZ3lHNnExVFMyUlQxMkZ3X2RRRDVVcjlZc1AwZlVWOXVtQWdGMC1jQ1EiXSwiX3NkX2FsZyI6InNoYS0yNTYifQ.ggEyE4SeDO2Hu3tol3VLmi7NQj56yKzKQDaafocgkLrUBdivghohtzrfcbrMN7CRufJ_Cnh0EL54kymXLGTdDQ~WyIwNGU0MjAzOWU4ZWFiOWRjIiwiYSIsIjEiXQ~WyIwOGE1Yjc5MjMyYjAzYzBhIiwiMSJd~WyJiNWE2YjUzZGQwYTFmMGIwIiwienp6IiwieHh4Il0~WyIxYzdmOTE4ZTE0MjA2NzZiIiwiZm9vIiwiYmFyIl0~WyJmZjYxYzQ5ZGU2NjFiYzMxIiwiYXJyIixbeyIuLi4iOiJTSG96VW5KNUpkd0ZtTjVCbXB5dXZCWGZfZWRjckVvcExPYThTVlBFUmg0In0sIjIiLHsiX3NkIjpbIkpuODNhZkp0OGx4NG1FMzZpRkZyS2U2R2VnN0dlVUQ4Z3UwdVo3NnRZcW8iXX1dXQ~';
     const decodedSdJwt = await decodeSdJwt(sdjwt, digest);
     const keys = await presentableKeys(
+      decodedSdJwt.jwt.payload,
+      decodedSdJwt.disclosures,
+      digest,
+    );
+    expect(keys).toStrictEqual(['arr', 'arr.0', 'arr.2.a', 'foo', 'test.zzz']);
+  });
+
+  test('presentableKeys sync', () => {
+    const sdjwt =
+      'eyJ0eXAiOiJzZC1qd3QiLCJhbGciOiJFZERTQSJ9.eyJ0ZXN0Ijp7Il9zZCI6WyJqVEszMHNleDZhYV9kUk1KSWZDR056Q0FwbVB5MzRRNjNBa3QzS3hhSktzIl19LCJfc2QiOlsiME9nMi1ReG95eW1UOGNnVzZZUjVSSFpQLUJuR2tHUi1NM2otLV92RWlzSSIsIkcwZ3lHNnExVFMyUlQxMkZ3X2RRRDVVcjlZc1AwZlVWOXVtQWdGMC1jQ1EiXSwiX3NkX2FsZyI6InNoYS0yNTYifQ.ggEyE4SeDO2Hu3tol3VLmi7NQj56yKzKQDaafocgkLrUBdivghohtzrfcbrMN7CRufJ_Cnh0EL54kymXLGTdDQ~WyIwNGU0MjAzOWU4ZWFiOWRjIiwiYSIsIjEiXQ~WyIwOGE1Yjc5MjMyYjAzYzBhIiwiMSJd~WyJiNWE2YjUzZGQwYTFmMGIwIiwienp6IiwieHh4Il0~WyIxYzdmOTE4ZTE0MjA2NzZiIiwiZm9vIiwiYmFyIl0~WyJmZjYxYzQ5ZGU2NjFiYzMxIiwiYXJyIixbeyIuLi4iOiJTSG96VW5KNUpkd0ZtTjVCbXB5dXZCWGZfZWRjckVvcExPYThTVlBFUmg0In0sIjIiLHsiX3NkIjpbIkpuODNhZkp0OGx4NG1FMzZpRkZyS2U2R2VnN0dlVUQ4Z3UwdVo3NnRZcW8iXX1dXQ~';
+    const decodedSdJwt = decodeSdJwtSync(sdjwt, digest);
+    const keys = presentableKeysSync(
       decodedSdJwt.jwt.payload,
       decodedSdJwt.disclosures,
       digest,
@@ -29,11 +46,34 @@ describe('Present tests', () => {
     );
   });
 
+  test('present sync', () => {
+    const sdjwt =
+      'eyJ0eXAiOiJzZC1qd3QiLCJhbGciOiJFZERTQSJ9.eyJ0ZXN0Ijp7Il9zZCI6WyJqVEszMHNleDZhYV9kUk1KSWZDR056Q0FwbVB5MzRRNjNBa3QzS3hhSktzIl19LCJfc2QiOlsiME9nMi1ReG95eW1UOGNnVzZZUjVSSFpQLUJuR2tHUi1NM2otLV92RWlzSSIsIkcwZ3lHNnExVFMyUlQxMkZ3X2RRRDVVcjlZc1AwZlVWOXVtQWdGMC1jQ1EiXSwiX3NkX2FsZyI6InNoYS0yNTYifQ.ggEyE4SeDO2Hu3tol3VLmi7NQj56yKzKQDaafocgkLrUBdivghohtzrfcbrMN7CRufJ_Cnh0EL54kymXLGTdDQ~WyIwNGU0MjAzOWU4ZWFiOWRjIiwiYSIsIjEiXQ~WyIwOGE1Yjc5MjMyYjAzYzBhIiwiMSJd~WyJiNWE2YjUzZGQwYTFmMGIwIiwienp6IiwieHh4Il0~WyIxYzdmOTE4ZTE0MjA2NzZiIiwiZm9vIiwiYmFyIl0~WyJmZjYxYzQ5ZGU2NjFiYzMxIiwiYXJyIixbeyIuLi4iOiJTSG96VW5KNUpkd0ZtTjVCbXB5dXZCWGZfZWRjckVvcExPYThTVlBFUmg0In0sIjIiLHsiX3NkIjpbIkpuODNhZkp0OGx4NG1FMzZpRkZyS2U2R2VnN0dlVUQ4Z3UwdVo3NnRZcW8iXX1dXQ~';
+    const presentedSdJwt = presentSync(
+      sdjwt,
+      ['foo', 'arr.0', 'test.zzz'],
+      digest,
+    );
+    expect(presentedSdJwt).toStrictEqual(
+      'eyJ0eXAiOiJzZC1qd3QiLCJhbGciOiJFZERTQSJ9.eyJ0ZXN0Ijp7Il9zZCI6WyJqVEszMHNleDZhYV9kUk1KSWZDR056Q0FwbVB5MzRRNjNBa3QzS3hhSktzIl19LCJfc2QiOlsiME9nMi1ReG95eW1UOGNnVzZZUjVSSFpQLUJuR2tHUi1NM2otLV92RWlzSSIsIkcwZ3lHNnExVFMyUlQxMkZ3X2RRRDVVcjlZc1AwZlVWOXVtQWdGMC1jQ1EiXSwiX3NkX2FsZyI6InNoYS0yNTYifQ.ggEyE4SeDO2Hu3tol3VLmi7NQj56yKzKQDaafocgkLrUBdivghohtzrfcbrMN7CRufJ_Cnh0EL54kymXLGTdDQ~WyIxYzdmOTE4ZTE0MjA2NzZiIiwiZm9vIiwiYmFyIl0~WyIwOGE1Yjc5MjMyYjAzYzBhIiwiMSJd~WyJiNWE2YjUzZGQwYTFmMGIwIiwienp6IiwieHh4Il0~',
+    );
+  });
+
   test('present error', async () => {
     const sdjwt =
       'eyJ0eXAiOiJzZC1qd3QiLCJhbGciOiJFZERTQSJ9.eyJ0ZXN0Ijp7Il9zZCI6WyJqVEszMHNleDZhYV9kUk1KSWZDR056Q0FwbVB5MzRRNjNBa3QzS3hhSktzIl19LCJfc2QiOlsiME9nMi1ReG95eW1UOGNnVzZZUjVSSFpQLUJuR2tHUi1NM2otLV92RWlzSSIsIkcwZ3lHNnExVFMyUlQxMkZ3X2RRRDVVcjlZc1AwZlVWOXVtQWdGMC1jQ1EiXSwiX3NkX2FsZyI6InNoYS0yNTYifQ.ggEyE4SeDO2Hu3tol3VLmi7NQj56yKzKQDaafocgkLrUBdivghohtzrfcbrMN7CRufJ_Cnh0EL54kymXLGTdDQ~WyIwNGU0MjAzOWU4ZWFiOWRjIiwiYSIsIjEiXQ~WyIwOGE1Yjc5MjMyYjAzYzBhIiwiMSJd~WyJiNWE2YjUzZGQwYTFmMGIwIiwienp6IiwieHh4Il0~WyIxYzdmOTE4ZTE0MjA2NzZiIiwiZm9vIiwiYmFyIl0~WyJmZjYxYzQ5ZGU2NjFiYzMxIiwiYXJyIixbeyIuLi4iOiJTSG96VW5KNUpkd0ZtTjVCbXB5dXZCWGZfZWRjckVvcExPYThTVlBFUmg0In0sIjIiLHsiX3NkIjpbIkpuODNhZkp0OGx4NG1FMzZpRkZyS2U2R2VnN0dlVUQ4Z3UwdVo3NnRZcW8iXX1dXQ~';
     try {
       await present(sdjwt, ['notthekey'], digest);
+    } catch (e) {
+      expect(e).toBeDefined();
+    }
+  });
+
+  test('present error sync', () => {
+    const sdjwt =
+      'eyJ0eXAiOiJzZC1qd3QiLCJhbGciOiJFZERTQSJ9.eyJ0ZXN0Ijp7Il9zZCI6WyJqVEszMHNleDZhYV9kUk1KSWZDR056Q0FwbVB5MzRRNjNBa3QzS3hhSktzIl19LCJfc2QiOlsiME9nMi1ReG95eW1UOGNnVzZZUjVSSFpQLUJuR2tHUi1NM2otLV92RWlzSSIsIkcwZ3lHNnExVFMyUlQxMkZ3X2RRRDVVcjlZc1AwZlVWOXVtQWdGMC1jQ1EiXSwiX3NkX2FsZyI6InNoYS0yNTYifQ.ggEyE4SeDO2Hu3tol3VLmi7NQj56yKzKQDaafocgkLrUBdivghohtzrfcbrMN7CRufJ_Cnh0EL54kymXLGTdDQ~WyIwNGU0MjAzOWU4ZWFiOWRjIiwiYSIsIjEiXQ~WyIwOGE1Yjc5MjMyYjAzYzBhIiwiMSJd~WyJiNWE2YjUzZGQwYTFmMGIwIiwienp6IiwieHh4Il0~WyIxYzdmOTE4ZTE0MjA2NzZiIiwiZm9vIiwiYmFyIl0~WyJmZjYxYzQ5ZGU2NjFiYzMxIiwiYXJyIixbeyIuLi4iOiJTSG96VW5KNUpkd0ZtTjVCbXB5dXZCWGZfZWRjckVvcExPYThTVlBFUmg0In0sIjIiLHsiX3NkIjpbIkpuODNhZkp0OGx4NG1FMzZpRkZyS2U2R2VnN0dlVUQ4Z3UwdVo3NnRZcW8iXX1dXQ~';
+    try {
+      presentSync(sdjwt, ['notthekey'], digest);
     } catch (e) {
       expect(e).toBeDefined();
     }

--- a/packages/types/src/type.ts
+++ b/packages/types/src/type.ts
@@ -46,6 +46,16 @@ export type HasherAndAlg = {
   alg: string;
 };
 
+// This functions are sync versions
+export type SignerSync = (data: string) => string;
+export type VerifierSync = (data: string, sig: string) => boolean;
+export type HasherSync = (data: string, alg: string) => Uint8Array;
+export type SaltGeneratorSync = (length: number) => string;
+export type HasherAndAlgSync = {
+  hasher: HasherSync;
+  alg: string;
+};
+
 type NonNever<T> = {
   [P in keyof T as T[P] extends never ? never : P]: T[P];
 };

--- a/packages/utils/src/disclosure.ts
+++ b/packages/utils/src/disclosure.ts
@@ -4,7 +4,11 @@ import {
   Base64urlEncode,
 } from './base64url';
 import { SDJWTException } from './error';
-import { HasherAndAlg, DisclosureData } from '@hopae/sd-jwt-type';
+import {
+  HasherAndAlg,
+  DisclosureData,
+  HasherAndAlgSync,
+} from '@hopae/sd-jwt-type';
 
 export class Disclosure<T> {
   public salt: string;
@@ -46,6 +50,14 @@ export class Disclosure<T> {
     return Disclosure.fromArray<T>(item, { digest: digestStr, encoded: s });
   }
 
+  public static fromEncodeSync<T>(s: string, hash: HasherAndAlgSync) {
+    const { hasher, alg } = hash;
+    const digest = hasher(s, alg);
+    const digestStr = Uint8ArrayToBase64Url(digest);
+    const item = JSON.parse(Base64urlDecode(s)) as DisclosureData<T>;
+    return Disclosure.fromArray<T>(item, { digest: digestStr, encoded: s });
+  }
+
   public static fromArray<T>(
     item: DisclosureData<T>,
     _meta?: { digest: string; encoded: string },
@@ -72,6 +84,16 @@ export class Disclosure<T> {
     const { hasher, alg } = hash;
     if (!this._digest) {
       const hash = await hasher(this.encode(), alg);
+      this._digest = Uint8ArrayToBase64Url(hash);
+    }
+
+    return this._digest;
+  }
+
+  public digestSync(hash: HasherAndAlgSync): string {
+    const { hasher, alg } = hash;
+    if (!this._digest) {
+      const hash = hasher(this.encode(), alg);
       this._digest = Uint8ArrayToBase64Url(hash);
     }
 


### PR DESCRIPTION
Support sync functions for decode/present packages

### Additional changes

- node digest helper function in `sd-jwt-node-crypto` changed to sync function