### PR TITLE
fix: ci publish action

### DIFF
--- a/.github/workflows/build-test-publish-on-push-cached.yaml
+++ b/.github/workflows/build-test-publish-on-push-cached.yaml
@@ -117,18 +117,18 @@ jobs:
       - test
       - lint
     env:
-      NPM_TOKEN: ${{secrets.NPM_TOKEN}}
-      NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
-      GH_TOKEN: ${{secrets.GH_TOKEN}}
-      GITHUB_TOKEN: ${{secrets.GH_TOKEN}}
-      GH_USER: ${{secrets.GH_USER}}
-      GH_EMAIL: ${{secrets.GH_EMAIL}}
+      NPM_TOKEN: ${{secrets.NPM_TOKEN }}
+      NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN }}
+      GH_TOKEN: ${{secrets.GITHUB_TOKEN }}
+      GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN }}
+      GH_USER: github-actions
+      GH_EMAIL: github-actions@github.com
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{secrets.GH_TOKEN}}
+          token: ${{secrets.GITHUB_TOKEN }}
       - uses: pnpm/action-setup@v3
         with:
           version: 8
@@ -149,7 +149,7 @@ jobs:
 
       - name: 'Setup git coordinates'
         run: |
-          git remote set-url origin https://${{secrets.GH_USER}}:${{secrets.GH_TOKEN}}@github.com/${{ github.repository }}.git
+          git remote set-url origin https://${{github.actor}}:${{secrets.GITHUB_TOKEN}}@github.com/${{ github.repository }}.git
           git config user.name $GH_USER
           git config user.email $GH_EMAIL
 


### PR DESCRIPTION
closes: #44 

Updates the used variables so the action runs.

@lukasjhan 
we need to define what is the "primary" branch. Veramo has this logic:
- next is defined as the "default" branch where everything is merged. A commit to this branch will make a release for "next".
- main is the branch holding the latest release. The difference between next and main is that not for every PR a new version is generated, but Authors are able to decide when it's time to create a new release on github (and to publish a new release version on npmjs). This will also set the :latest version on npmjs.
- unstable: allows to push a version to npmjs for testing. It is not required to be first pushed to unstable, then to next and then to main. I am not quite sure if we need this stage. Maybe we can remove it in the future

This approach allows to have a tested version approach (because when we saw some bug on the next release, we can overwrite it in an easy way). On the other hand it's still the classic approach for the user because he can use latest or no version number during the installation to make sure he gets the latest released version.