### PR TITLE
fix: add publish config

### DIFF
--- a/packages/broswer-crypto/package.json
+++ b/packages/broswer-crypto/package.json
@@ -33,6 +33,9 @@
     "url": "https://github.com/openwallet-foundation-labs/sd-jwt-js/issues"
   },
   "license": "Apache-2.0",
+  "publishConfig": {
+    "access": "public"
+  },
   "tsup": {
     "entry": [
       "./src/index.ts"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -43,6 +43,9 @@
     "@sd-jwt/types": "workspace:*",
     "@sd-jwt/utils": "workspace:*"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "tsup": {
     "entry": [
       "./src/index.ts"

--- a/packages/decode/package.json
+++ b/packages/decode/package.json
@@ -40,6 +40,9 @@
     "@sd-jwt/types": "workspace:*",
     "@sd-jwt/utils": "workspace:*"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "tsup": {
     "entry": [
       "./src/index.ts"

--- a/packages/hash/package.json
+++ b/packages/hash/package.json
@@ -41,6 +41,9 @@
     "@sd-jwt/utils": "workspace:*",
     "@noble/hashes": "1.0.0"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "tsup": {
     "entry": [
       "./src/index.ts"

--- a/packages/node-crypto/package.json
+++ b/packages/node-crypto/package.json
@@ -33,6 +33,9 @@
     "url": "https://github.com/openwallet-foundation-labs/sd-jwt-js/issues"
   },
   "license": "Apache-2.0",
+  "publishConfig": {
+    "access": "public"
+  },
   "tsup": {
     "entry": [
       "./src/index.ts"

--- a/packages/present/package.json
+++ b/packages/present/package.json
@@ -42,6 +42,9 @@
     "@sd-jwt/types": "workspace:*",
     "@sd-jwt/utils": "workspace:*"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "tsup": {
     "entry": [
       "./src/index.ts"

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -34,6 +34,9 @@
     "url": "https://github.com/openwallet-foundation-labs/sd-jwt-js/issues"
   },
   "license": "Apache-2.0",
+  "publishConfig": {
+    "access": "public"
+  },
   "tsup": {
     "entry": [
       "./src/index.ts"

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -41,6 +41,9 @@
     "@sd-jwt/types": "workspace:*",
     "js-base64": "^3.7.6"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "tsup": {
     "entry": [
       "./src/index.ts"


### PR DESCRIPTION
adding `publishConfig` with access:public

the no-private param only is to exclude private packages from being processed.