### PR TITLE
chore: add missing tests for browser

### DIFF
--- a/packages/browser-crypto/src/crypto.ts
+++ b/packages/browser-crypto/src/crypto.ts
@@ -2,9 +2,9 @@ export const generateSalt = (length: number): string => {
   if (length <= 0) {
     return '';
   }
-
-  const array = new Uint8Array(length);
-  globalThis.crypto.getRandomValues(array);
+  // a hex is represented by 2 characters, so we split the length by 2
+  const array = new Uint8Array(length / 2);
+  window.crypto.getRandomValues(array);
 
   const salt = Array.from(array, (byte) =>
     byte.toString(16).padStart(2, '0'),

--- a/packages/browser-crypto/src/test/crypto.spec.ts
+++ b/packages/browser-crypto/src/test/crypto.spec.ts
@@ -1,7 +1,39 @@
 import { describe, expect, test } from 'vitest';
+import { generateSalt, digest, getHasher } from '../index';
 
 describe('This file is for utility functions', () => {
   test('crypto', () => {
     expect('1').toStrictEqual('1');
+  });
+
+  test('generateSalt', async () => {
+    const salt = generateSalt(8);
+    expect(salt).toBeDefined();
+    expect(salt.length).toBe(8);
+  });
+
+  test('generateSalt 0 length', async () => {
+    const salt = generateSalt(0);
+    expect(salt).toBeDefined();
+    expect(salt.length).toBe(0);
+  });
+
+  test('digest', async () => {
+    const payload = 'test1';
+    const s1 = await digest(payload);
+    expect(s1).toBeDefined();
+    expect(s1.length).toBe(32);
+  });
+
+  test('digest', async () => {
+    const payload = 'test1';
+    const s1 = await digest(payload, 'SHA-512');
+    expect(s1).toBeDefined();
+    expect(s1.length).toBe(64);
+  });
+
+  test('get hasher', async () => {
+    const hash = await getHasher('SHA-512')('test1');
+    expect(hash).toBeDefined();
   });
 });


### PR DESCRIPTION
Adding missing tests for the brower.

@lukasjhan since we have a coverage of 100% for browser and I am calling the window.crypto api, it seems that vitest is able to interact with this.

I haven't tested your PR with this yet