### PR TITLE
feat: calcuate sd_hash in kb JWT

### DIFF
--- a/examples/core-example/kb.ts
+++ b/examples/core-example/kb.ts
@@ -31,7 +31,6 @@ import { createSignerVerifier, digest, generateSalt } from './utils';
     aud: 'https://example.com',
     nonce: '1234',
     custom: 'data',
-    sd_hash: '1234',
   };
 
   const encodedSdjwt = await sdjwt.issue(claims, disclosureFrame);

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,4 +1,4 @@
-import { SDJWTException } from '@sd-jwt/utils';
+import { SDJWTException, Uint8ArrayToBase64Url } from '@sd-jwt/utils';
 import { Jwt } from './jwt';
 import { KBJwt } from './kbjwt';
 import { SDJwt, pack } from './sdjwt';
@@ -10,6 +10,7 @@ import {
   SDJWTConfig,
   SD_JWT_TYP,
 } from '@sd-jwt/types';
+import { getSDAlgAndPayload } from '@sd-jwt/decode';
 
 export * from './sdjwt';
 export * from './kbjwt';
@@ -27,20 +28,24 @@ export class SDJwtInstance {
     }
   }
 
-  private async createKBJwt(options: KBOptions): Promise<KBJwt> {
+  private async createKBJwt(
+    options: KBOptions,
+    sdHash: string,
+  ): Promise<KBJwt> {
     if (!this.userConfig.kbSigner) {
       throw new SDJWTException('Key Binding Signer not found');
     }
     if (!this.userConfig.kbSignAlg) {
       throw new SDJWTException('Key Binding sign algorithm not specified');
     }
+
     const { payload } = options;
     const kbJwt = new KBJwt({
       header: {
         typ: KB_JWT_TYP,
         alg: this.userConfig.kbSignAlg,
       },
-      payload,
+      payload: { ...payload, sd_hash: sdHash },
     });
 
     await kbJwt.sign(this.userConfig.kbSigner);
@@ -127,9 +132,22 @@ export class SDJwtInstance {
     const hasher = this.userConfig.hasher;
 
     const sdjwt = await SDJwt.fromEncode(encodedSDJwt, hasher);
-    const kbJwt = options?.kb ? await this.createKBJwt(options.kb) : undefined;
-    sdjwt.kbJwt = kbJwt;
 
+    if (!sdjwt.jwt?.payload) throw new SDJWTException('Payload not found');
+    const presentSdJwtWithoutKb = await sdjwt.present(
+      presentationKeys.sort(),
+      hasher,
+    );
+
+    if (!options?.kb) {
+      return presentSdJwtWithoutKb;
+    }
+
+    const { _sd_alg } = getSDAlgAndPayload(sdjwt.jwt.payload);
+    const sdHash = await hasher(presentSdJwtWithoutKb, _sd_alg);
+    const sdHashStr = Uint8ArrayToBase64Url(sdHash);
+
+    sdjwt.kbJwt = await this.createKBJwt(options.kb, sdHashStr);
     return sdjwt.present(presentationKeys.sort(), hasher);
   }
 
@@ -147,7 +165,7 @@ export class SDJwtInstance {
     const hasher = this.userConfig.hasher;
 
     const sdjwt = await SDJwt.fromEncode(encodedSDJwt, hasher);
-    if (!sdjwt.jwt) {
+    if (!sdjwt.jwt || !sdjwt.jwt.payload) {
       throw new SDJWTException('Invalid SD JWT');
     }
     const { payload, header } = await this.validate(encodedSDJwt);
@@ -173,6 +191,21 @@ export class SDJwtInstance {
       throw new SDJWTException('Key Binding Verifier not found');
     }
     const kb = await sdjwt.kbJwt.verify(this.userConfig.kbVerifier);
+    const sdHashfromKb = kb.payload.sd_hash;
+    const sdjwtWithoutKb = new SDJwt({
+      jwt: sdjwt.jwt,
+      disclosures: sdjwt.disclosures,
+    });
+
+    const presentSdJwtWithoutKb = sdjwtWithoutKb.encodeSDJwt();
+    const { _sd_alg } = getSDAlgAndPayload(sdjwt.jwt.payload);
+    const sdHash = await hasher(presentSdJwtWithoutKb, _sd_alg);
+    const sdHashStr = Uint8ArrayToBase64Url(sdHash);
+
+    if (sdHashStr !== sdHashfromKb) {
+      throw new SDJWTException('Invalid sd_hash in Key Binding JWT');
+    }
+
     return { payload, header, kb };
   }
 

--- a/packages/core/src/sdjwt.ts
+++ b/packages/core/src/sdjwt.ts
@@ -6,12 +6,15 @@ import {
   DisclosureFrame,
   Hasher,
   HasherAndAlg,
+  KBOptions,
+  KB_JWT_TYP,
   SDJWTCompact,
   SD_DECOY,
   SD_DIGEST,
   SD_LIST_KEY,
   SD_SEPARATOR,
   SaltGenerator,
+  Signer,
   kbHeader,
   kbPayload,
 } from '@sd-jwt/types';
@@ -112,6 +115,25 @@ export class SDJwt<
       disclosures,
       kbJwt,
     });
+  }
+
+  private async createKBJwt(
+    options: KBOptions,
+    sdHash: string,
+    kbSigner: Signer,
+    kbSignAlg: string,
+  ): Promise<KBJwt> {
+    const { payload } = options;
+    const kbJwt = new KBJwt({
+      header: {
+        typ: KB_JWT_TYP,
+        alg: kbSignAlg,
+      },
+      payload: { ...payload, sd_hash: sdHash },
+    });
+
+    await kbJwt.sign(kbSigner);
+    return kbJwt;
   }
 
   public async present(keys: string[], hasher: Hasher): Promise<SDJWTCompact> {

--- a/packages/core/src/sdjwt.ts
+++ b/packages/core/src/sdjwt.ts
@@ -117,25 +117,6 @@ export class SDJwt<
     });
   }
 
-  private async createKBJwt(
-    options: KBOptions,
-    sdHash: string,
-    kbSigner: Signer,
-    kbSignAlg: string,
-  ): Promise<KBJwt> {
-    const { payload } = options;
-    const kbJwt = new KBJwt({
-      header: {
-        typ: KB_JWT_TYP,
-        alg: kbSignAlg,
-      },
-      payload: { ...payload, sd_hash: sdHash },
-    });
-
-    await kbJwt.sign(kbSigner);
-    return kbJwt;
-  }
-
   public async present(keys: string[], hasher: Hasher): Promise<SDJWTCompact> {
     if (!this.jwt?.payload || !this.disclosures) {
       throw new SDJWTException('Invalid sd-jwt: jwt or disclosures is missing');

--- a/packages/core/src/test/index.spec.ts
+++ b/packages/core/src/test/index.spec.ts
@@ -52,7 +52,6 @@ describe('index', () => {
     const presentation = await sdjwt.present(credential, ['foo'], {
       kb: {
         payload: {
-          sd_hash: 'sha-256',
           aud: '1',
           iat: 1,
           nonce: '342',
@@ -154,8 +153,7 @@ describe('index', () => {
     const presentation = await sdjwt.present(credential, ['foo'], {
       kb: {
         payload: {
-          sd_hash: '',
-          aud: '1',
+          aud: '',
           iat: 1,
           nonce: '342',
         },
@@ -194,7 +192,6 @@ describe('index', () => {
     const presentation = await sdjwt.present(credential, ['foo'], {
       kb: {
         payload: {
-          sd_hash: 'sha-256',
           aud: '1',
           iat: 1,
           nonce: '342',
@@ -289,7 +286,6 @@ describe('index', () => {
     const presentation = await sdjwt.present(credential, ['foo'], {
       kb: {
         payload: {
-          sd_hash: 'sha-256',
           aud: '1',
           iat: 1,
           nonce: '342',
@@ -327,7 +323,6 @@ describe('index', () => {
       const presentation = await sdjwt.present(credential, ['foo'], {
         kb: {
           payload: {
-            sd_hash: 'sha-256',
             aud: '1',
             iat: 1,
             nonce: '342',
@@ -363,7 +358,6 @@ describe('index', () => {
     const presentation = await sdjwt.present(credential, ['foo'], {
       kb: {
         payload: {
-          sd_hash: 'sha-256',
           aud: '1',
           iat: 1,
           nonce: '342',

--- a/packages/types/src/type.ts
+++ b/packages/types/src/type.ts
@@ -104,14 +104,14 @@ type Frame<Payload> = Payload extends Array<infer U>
     ? Record<number, Frame<U>> & SD<Payload> & DECOY
     : SD<Payload> & DECOY
   : Payload extends Record<string, unknown>
-  ? NonNever<
-      {
-        [K in keyof Payload]?: Payload[K] extends object
-          ? Frame<Payload[K]>
-          : never;
-      } & SD<Payload> &
-        DECOY
-    >
-  : SD<Payload> & DECOY;
+    ? NonNever<
+        {
+          [K in keyof Payload]?: Payload[K] extends object
+            ? Frame<Payload[K]>
+            : never;
+        } & SD<Payload> &
+          DECOY
+      >
+    : SD<Payload> & DECOY;
 
 export type DisclosureFrame<T extends object> = Frame<T>;

--- a/packages/types/src/type.ts
+++ b/packages/types/src/type.ts
@@ -32,7 +32,7 @@ export type kbPayload = {
 };
 
 export type KBOptions = {
-  payload: kbPayload;
+  payload: Omit<kbPayload, 'sd_hash'>;
 };
 
 export type OrPromise<T> = T | Promise<T>;
@@ -104,14 +104,14 @@ type Frame<Payload> = Payload extends Array<infer U>
     ? Record<number, Frame<U>> & SD<Payload> & DECOY
     : SD<Payload> & DECOY
   : Payload extends Record<string, unknown>
-    ? NonNever<
-        {
-          [K in keyof Payload]?: Payload[K] extends object
-            ? Frame<Payload[K]>
-            : never;
-        } & SD<Payload> &
-          DECOY
-      >
-    : SD<Payload> & DECOY;
+  ? NonNever<
+      {
+        [K in keyof Payload]?: Payload[K] extends object
+          ? Frame<Payload[K]>
+          : never;
+      } & SD<Payload> &
+        DECOY
+    >
+  : SD<Payload> & DECOY;
 
 export type DisclosureFrame<T extends object> = Frame<T>;


### PR DESCRIPTION
sd_hash is a base64url hash digest of the presented SD-JWT. So we can calculate that value in our logic.

It closes #108