### PR TITLE
feat: fixing exclude _sd_alg when no disclosure

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -100,7 +100,7 @@ export class SDJwtInstance {
       header,
       payload: {
         ...packedClaims,
-        _sd_alg: hashAlg,
+        _sd_alg: disclosureFrame ? hashAlg : undefined,
       },
     });
     await this.SignJwt(jwt);


### PR DESCRIPTION
I always set `_sd_alg` in payload even if there is no disclosure. But I think it's better not to include when there is nothing.
I guess it's more complaint.

> When used, this claim MUST appear at the top level of the SD-JWT payload.

> The payload MAY contain the _sd_alg key described in [Section 5.1.1](https://www.ietf.org/archive/id/draft-ietf-oauth-selective-disclosure-jwt-07.html#hash_function_claim).