### PR TITLE
Implement kbverify function

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "lint": "biome lint ./packages",
     "format": "biome format . --write",
     "test": "vitest run --coverage.enabled=true --coverage.include=packages/*",
+    "test:watch": "vitest",
     "clean": "lerna clean -y",
     "publish:latest": "lerna publish --no-private --conventional-commits --include-merged-tags --create-release github --yes --dist-tag latest",
     "publish:next": "lerna publish --no-private --conventional-prerelease --force-publish --canary --no-git-tag-version --include-merged-tags --preid next --pre-dist-tag next --yes",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "@biomejs/biome": "1.5.3",
     "@types/node": "^20.10.2",
     "@vitest/coverage-v8": "^1.2.2",
+    "jose": "^5.2.2",
     "jsdom": "^24.0.0",
     "lerna": "^8.1.2",
     "ts-node": "^10.9.1",

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -11,6 +11,7 @@ import {
   SDJWTConfig,
 } from '@sd-jwt/types';
 import { getSDAlgAndPayload } from '@sd-jwt/decode';
+import { JwtPayload } from '@sd-jwt/types';
 
 export * from './sdjwt';
 export * from './kbjwt';
@@ -212,7 +213,13 @@ export class SDJwtInstance<ExtendedPayload extends SdJwtPayload> {
     if (!this.userConfig.kbVerifier) {
       throw new SDJWTException('Key Binding Verifier not found');
     }
-    const kb = await sdjwt.kbJwt.verify(this.userConfig.kbVerifier);
+    const kb = await sdjwt.kbJwt.verifyKB({
+      verifier: this.userConfig.kbVerifier,
+      payload: payload as JwtPayload,
+    });
+    if (!kb) {
+      throw new Error('signature is not valid');
+    }
     const sdHashfromKb = kb.payload.sd_hash;
     const sdjwtWithoutKb = new SDJwt({
       jwt: sdjwt.jwt,

--- a/packages/node-crypto/src/crypto.ts
+++ b/packages/node-crypto/src/crypto.ts
@@ -1,4 +1,4 @@
-import { createHash, randomBytes } from 'crypto';
+import { createHash, randomBytes, subtle } from 'crypto';
 
 export const generateSalt = (length: number): string => {
   if (length <= 0) {
@@ -24,7 +24,6 @@ export const ES256 = {
   alg: 'ES256',
 
   async generateKeyPair() {
-    const { subtle } = globalThis.crypto;
     const keyPair = await subtle.generateKey(
       {
         name: 'ECDSA',
@@ -42,7 +41,6 @@ export const ES256 = {
   },
 
   async getSigner(privateKeyJWK: object) {
-    const { subtle } = globalThis.crypto;
     const privateKey = await subtle.importKey(
       'jwk',
       privateKeyJWK,
@@ -73,7 +71,6 @@ export const ES256 = {
   },
 
   async getVerifier(publicKeyJWK: object) {
-    const { subtle } = globalThis.crypto;
     const publicKey = await subtle.importKey(
       'jwk',
       publicKeyJWK,

--- a/packages/types/src/type.ts
+++ b/packages/types/src/type.ts
@@ -19,7 +19,7 @@ export type SDJWTConfig = {
   verifier?: Verifier;
   kbSigner?: Signer;
   kbSignAlg?: string;
-  kbVerifier?: Verifier;
+  kbVerifier?: KbVerifier;
 };
 
 export type kbHeader = { typ: 'kb+jwt'; alg: string };
@@ -34,10 +34,22 @@ export type KBOptions = {
   payload: Omit<kbPayload, 'sd_hash'>;
 };
 
+export interface JwtPayload {
+  cnf?: {
+    jwk: JsonWebKey;
+  };
+  [key: string]: unknown;
+}
+
 export type OrPromise<T> = T | Promise<T>;
 
 export type Signer = (data: string) => OrPromise<string>;
 export type Verifier = (data: string, sig: string) => OrPromise<boolean>;
+export type KbVerifier = (
+  data: string,
+  sig: string,
+  payload: JwtPayload,
+) => OrPromise<boolean>;
 export type Hasher = (data: string, alg: string) => OrPromise<Uint8Array>;
 export type SaltGenerator = (length: number) => OrPromise<string>;
 export type HasherAndAlg = {
@@ -103,14 +115,14 @@ type Frame<Payload> = Payload extends Array<infer U>
     ? Record<number, Frame<U>> & SD<Payload> & DECOY
     : SD<Payload> & DECOY
   : Payload extends Record<string, unknown>
-    ? NonNever<
-        {
-          [K in keyof Payload]?: Payload[K] extends object
-            ? Frame<Payload[K]>
-            : never;
-        } & SD<Payload> &
-          DECOY
-      >
-    : SD<Payload> & DECOY;
+  ? NonNever<
+      {
+        [K in keyof Payload]?: Payload[K] extends object
+          ? Frame<Payload[K]>
+          : never;
+      } & SD<Payload> &
+        DECOY
+    >
+  : SD<Payload> & DECOY;
 
 export type DisclosureFrame<T extends object> = Frame<T>;

--- a/packages/types/src/type.ts
+++ b/packages/types/src/type.ts
@@ -115,14 +115,14 @@ type Frame<Payload> = Payload extends Array<infer U>
     ? Record<number, Frame<U>> & SD<Payload> & DECOY
     : SD<Payload> & DECOY
   : Payload extends Record<string, unknown>
-  ? NonNever<
-      {
-        [K in keyof Payload]?: Payload[K] extends object
-          ? Frame<Payload[K]>
-          : never;
-      } & SD<Payload> &
-        DECOY
-    >
-  : SD<Payload> & DECOY;
+    ? NonNever<
+        {
+          [K in keyof Payload]?: Payload[K] extends object
+            ? Frame<Payload[K]>
+            : never;
+        } & SD<Payload> &
+          DECOY
+      >
+    : SD<Payload> & DECOY;
 
 export type DisclosureFrame<T extends object> = Frame<T>;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       '@vitest/coverage-v8':
         specifier: ^1.2.2
         version: 1.3.1(vitest@1.3.1)
+      jose:
+        specifier: ^5.2.2
+        version: 5.2.2
       jsdom:
         specifier: ^24.0.0
         version: 24.0.0
@@ -3169,6 +3172,10 @@ packages:
   /jest-get-type@29.6.3:
     resolution: {integrity: sha512-zrteXnqYxfQh7l5FHyL38jL39di8H8rHoecLH3JNxH3BwOrBsNeabdap5e0I23lD4HHI8W5VFBZqG4Eaq5LNcw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    dev: true
+
+  /jose@5.2.2:
+    resolution: {integrity: sha512-/WByRr4jDcsKlvMd1dRJnPfS1GVO3WuKyaurJ/vvXcOaUQO8rnNObCQMlv/5uCceVQIq5Q4WLF44ohsdiTohdg==}
     dev: true
 
   /joycon@3.1.1:


### PR DESCRIPTION
closes #125 

Adds signature verification to the kbVerify function. The whole payload of the actual token is passed to the kbverify function, it is not needed in the constructor of the KBJWT since this would break the extension from JWT.

The fetching of the key has to be implemented by the user. The payload has an optional field [cnf](https://datatracker.ietf.org/doc/html/rfc7800#section-3.2). The user is free to get the key from another field like `subject`, `id` etc. and is also free to parse the value - no limitation if there is a did url, jwk or url pointing to a hosted public key.<

Since we need to pass the payload to the verify function, the verify function in KBJWT will not get overwritten, but there will be a new function. It looks better to do it this way than adding an optional field to the verify function in JWT that has no meaning just to be compliant with the other call. If someone know a more elegant way I am open for changes.