### PR TITLE
feat: create kb jwt when present all

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -146,7 +146,6 @@ export class SDJwtInstance<ExtendedPayload extends SdJwtPayload> {
       kb?: KBOptions;
     },
   ): Promise<SDJWTCompact> {
-    if (!presentationKeys) return encodedSDJwt;
     if (!this.userConfig.hasher) {
       throw new SDJWTException('Hasher not found');
     }
@@ -154,9 +153,12 @@ export class SDJwtInstance<ExtendedPayload extends SdJwtPayload> {
 
     const sdjwt = await SDJwt.fromEncode(encodedSDJwt, hasher);
 
+    const sortedpresentationKeys =
+      presentationKeys?.sort() ?? (await sdjwt.presentableKeys(hasher));
+
     if (!sdjwt.jwt?.payload) throw new SDJWTException('Payload not found');
     const presentSdJwtWithoutKb = await sdjwt.present(
-      presentationKeys.sort(),
+      sortedpresentationKeys,
       hasher,
     );
 
@@ -171,7 +173,7 @@ export class SDJwtInstance<ExtendedPayload extends SdJwtPayload> {
     );
 
     sdjwt.kbJwt = await this.createKBJwt(options.kb, sdHashStr);
-    return sdjwt.present(presentationKeys.sort(), hasher);
+    return sdjwt.present(sortedpresentationKeys, hasher);
   }
 
   // This function is for verifying the SD JWT

--- a/packages/core/src/test/index.spec.ts
+++ b/packages/core/src/test/index.spec.ts
@@ -525,4 +525,42 @@ describe('index', () => {
     expect(keys).toBeDefined();
     expect(keys).toEqual(['foo']);
   });
+
+  test('present all disclosures with kb jwt', async () => {
+    const { signer } = createSignerVerifier();
+    const sdjwt = new SDJwtInstance<SdJwtPayload>({
+      signer,
+      kbSigner: signer,
+      hasher: digest,
+      saltGenerator: generateSalt,
+      signAlg: 'EdDSA',
+      kbSignAlg: 'EdDSA',
+    });
+    const credential = await sdjwt.issue(
+      {
+        foo: 'bar',
+        iss: 'Issuer',
+        iat: new Date().getTime(),
+        vct: '',
+      },
+      {
+        _sd: ['foo'],
+      },
+    );
+
+    const presentation = await sdjwt.present(credential, undefined, {
+      kb: {
+        payload: {
+          aud: '1',
+          iat: 1,
+          nonce: '342',
+        },
+      },
+    });
+
+    const decoded = await sdjwt.decode(presentation);
+    expect(decoded.jwt).toBeDefined();
+    expect(decoded.disclosures).toBeDefined();
+    expect(decoded.kbJwt).toBeDefined();
+  });
 });


### PR DESCRIPTION
In present method, when `presentationKeys` is undefined, then present all disclosures. but in this case kbjwt is not created.
I fixed it to create kbjwt.  