### PR TITLE
feat: add jwk type

### DIFF
--- a/packages/core/src/test/index.spec.ts
+++ b/packages/core/src/test/index.spec.ts
@@ -1,9 +1,8 @@
 import { SDJwtInstance, SdJwtPayload } from '../index';
-import { Signer, Verifier } from '@sd-jwt/types';
+import { Signer, Verifier, KbVerifier, JwtPayload } from '@sd-jwt/types';
 import Crypto, { KeyLike } from 'node:crypto';
 import { describe, expect, test } from 'vitest';
 import { digest, generateSalt } from '@sd-jwt/crypto-nodejs';
-import { KbVerifier, JwtPayload } from '@sd-jwt/types';
 import { importJWK, exportJWK, JWK } from 'jose';
 
 export const createSignerVerifier = () => {

--- a/packages/types/src/type.ts
+++ b/packages/types/src/type.ts
@@ -136,14 +136,14 @@ type Frame<Payload> = Payload extends Array<infer U>
     ? Record<number, Frame<U>> & SD<Payload> & DECOY
     : SD<Payload> & DECOY
   : Payload extends Record<string, unknown>
-  ? NonNever<
-      {
-        [K in keyof Payload]?: Payload[K] extends object
-          ? Frame<Payload[K]>
-          : never;
-      } & SD<Payload> &
-        DECOY
-    >
-  : SD<Payload> & DECOY;
+    ? NonNever<
+        {
+          [K in keyof Payload]?: Payload[K] extends object
+            ? Frame<Payload[K]>
+            : never;
+        } & SD<Payload> &
+          DECOY
+      >
+    : SD<Payload> & DECOY;
 
 export type DisclosureFrame<T extends object> = Frame<T>;

--- a/packages/types/src/type.ts
+++ b/packages/types/src/type.ts
@@ -34,6 +34,33 @@ export type KBOptions = {
   payload: Omit<kbPayload, 'sd_hash'>;
 };
 
+interface RsaOtherPrimesInfo {
+  d?: string;
+  r?: string;
+  t?: string;
+}
+
+interface JsonWebKey {
+  alg?: string;
+  crv?: string;
+  d?: string;
+  dp?: string;
+  dq?: string;
+  e?: string;
+  ext?: boolean;
+  k?: string;
+  key_ops?: string[];
+  kty?: string;
+  n?: string;
+  oth?: RsaOtherPrimesInfo[];
+  p?: string;
+  q?: string;
+  qi?: string;
+  use?: string;
+  x?: string;
+  y?: string;
+}
+
 export interface JwtPayload {
   cnf?: {
     jwk: JsonWebKey;

--- a/packages/types/src/type.ts
+++ b/packages/types/src/type.ts
@@ -34,12 +34,6 @@ export type KBOptions = {
   payload: Omit<kbPayload, 'sd_hash'>;
 };
 
-interface RsaOtherPrimesInfo {
-  d?: string;
-  r?: string;
-  t?: string;
-}
-
 interface JsonWebKey {
   alg?: string;
   crv?: string;
@@ -142,14 +136,14 @@ type Frame<Payload> = Payload extends Array<infer U>
     ? Record<number, Frame<U>> & SD<Payload> & DECOY
     : SD<Payload> & DECOY
   : Payload extends Record<string, unknown>
-    ? NonNever<
-        {
-          [K in keyof Payload]?: Payload[K] extends object
-            ? Frame<Payload[K]>
-            : never;
-        } & SD<Payload> &
-          DECOY
-      >
-    : SD<Payload> & DECOY;
+  ? NonNever<
+      {
+        [K in keyof Payload]?: Payload[K] extends object
+          ? Frame<Payload[K]>
+          : never;
+      } & SD<Payload> &
+        DECOY
+    >
+  : SD<Payload> & DECOY;
 
 export type DisclosureFrame<T extends object> = Frame<T>;


### PR DESCRIPTION
JsonWebKey type is in lib.dom.d.ts but some project might not want to include it tsconfig.json.
When I was trying to build credo-ts, It failed due to this. So I added it to our type file.