### PR TITLE
feat: fix async handling in jwt verify

### DIFF
--- a/packages/core/src/jwt.ts
+++ b/packages/core/src/jwt.ts
@@ -98,7 +98,7 @@ export class Jwt<
     const payload = Base64urlEncode(JSON.stringify(this.payload));
     const data = `${header}.${payload}`;
 
-    const verified = verifier(data, this.signature);
+    const verified = await verifier(data, this.signature);
     if (!verified) {
       throw new SDJWTException('Verify Error: Invalid JWT Signature');
     }


### PR DESCRIPTION
I found a bug while developing https://sdjwt.co

in jwt verify method, It doesn't wait until its resolved. verifier can be async function so we need await keyword.