### PR TITLE
feat: checking kb header value

### DIFF
--- a/packages/core/src/kbjwt.ts
+++ b/packages/core/src/kbjwt.ts
@@ -9,22 +9,25 @@ export class KBJwt<
   // Checking the validity of the key binding jwt
   // the type unknown is not good, but we don't know at this point how to get the public key of the signer, this is defined in the kbVerifier
   public async verifyKB(values: { verifier: KbVerifier; payload: JwtPayload }) {
+    if (!this.header || !this.payload || !this.signature) {
+      throw new SDJWTException('Verify Error: Invalid JWT');
+    }
+
     if (
-      !this.header?.alg ||
+      !this.header.alg ||
+      this.header.alg !== 'none' ||
       !this.header.typ ||
-      !this.payload?.iat ||
-      !this.payload?.aud ||
-      !this.payload?.nonce ||
+      this.header.typ !== 'kb+jwt' ||
+      !this.payload.iat ||
+      !this.payload.aud ||
+      !this.payload.nonce ||
       // this is for backward compatibility with version 06
       !(
-        this.payload?.sd_hash ||
+        this.payload.sd_hash ||
         (this.payload as Record<string, unknown> | undefined)?._sd_hash
       )
     ) {
       throw new SDJWTException('Invalid Key Binding Jwt');
-    }
-    if (!this.header || !this.payload || !this.signature) {
-      throw new SDJWTException('Verify Error: Invalid JWT');
     }
 
     const header = Base64urlEncode(JSON.stringify(this.header));

--- a/packages/core/src/kbjwt.ts
+++ b/packages/core/src/kbjwt.ts
@@ -1,6 +1,12 @@
 import { Base64urlEncode, SDJWTException } from '@sd-jwt/utils';
 import { Jwt } from './jwt';
-import { JwtPayload, kbHeader, kbPayload, KbVerifier } from '@sd-jwt/types';
+import {
+  JwtPayload,
+  KB_JWT_TYP,
+  kbHeader,
+  kbPayload,
+  KbVerifier,
+} from '@sd-jwt/types';
 
 export class KBJwt<
   Header extends kbHeader = kbHeader,
@@ -15,9 +21,9 @@ export class KBJwt<
 
     if (
       !this.header.alg ||
-      this.header.alg !== 'none' ||
+      this.header.alg === 'none' ||
       !this.header.typ ||
-      this.header.typ !== 'kb+jwt' ||
+      this.header.typ !== KB_JWT_TYP ||
       !this.payload.iat ||
       !this.payload.aud ||
       !this.payload.nonce ||


### PR DESCRIPTION
I added checking logic of header of key binding JWT.

I referenced from standard:

> 8.3.  Verification by the Verifier
> 3. Ensure that a signing algorithm was used that was deemede public key for the Holder from the SD-JWT
>     secure for the application.  Refer to [RFC8725], Sections 3.1
>     and 3.2 for details.  The none algorithm MUST NOT be accepted
>  5.  Check that the typ of the Key Binding JWT is kb+jwt.

