### PR TITLE
feat: make _digest value public in disclosure

### DIFF
--- a/.github/workflows/build-test-publish-on-push-cached.yaml
+++ b/.github/workflows/build-test-publish-on-push-cached.yaml
@@ -107,12 +107,12 @@ jobs:
         with:
           node-version: 20
           cache: 'pnpm'
-      - name: Setup Biome
-        uses: biomejs/setup-biome@v2
-        with:
-          version: latest
+      # - name: Setup Biome
+      #   uses: biomejs/setup-biome@v2
+      #   with:
+      #     version: latest
       - name: Run Biome
-        run: biome ci .
+        run: npx biome ci .
 
   # Only run this job when the push is on main, next or unstable
   publish:    

--- a/.github/workflows/build-test-publish-on-push-cached.yaml
+++ b/.github/workflows/build-test-publish-on-push-cached.yaml
@@ -107,12 +107,12 @@ jobs:
         with:
           node-version: 20
           cache: 'pnpm'
-      # - name: Setup Biome
-      #   uses: biomejs/setup-biome@v2
-      #   with:
-      #     version: latest
+      - name: Setup Biome
+        uses: biomejs/setup-biome@v2
+        with:
+          version: latest
       - name: Run Biome
-        run: npx biome ci .
+        run: biome ci .
 
   # Only run this job when the push is on main, next or unstable
   publish:    

--- a/.github/workflows/build-test-publish-on-push-cached.yaml
+++ b/.github/workflows/build-test-publish-on-push-cached.yaml
@@ -107,12 +107,9 @@ jobs:
         with:
           node-version: 20
           cache: 'pnpm'
-      - name: Setup Biome
-        uses: biomejs/setup-biome@v2
-        with:
-          version: latest
-      - name: Run Biome
-        run: biome ci .
+        # we are not using the github action for biome, but the package.json script. this makes sure we are using the same versions.
+      - name: Run Biome      
+        run: pnpm run biome:ci
 
   # Only run this job when the push is on main, next or unstable
   publish:    

--- a/examples/sd-jwt-example/all.ts
+++ b/examples/sd-jwt-example/all.ts
@@ -1,5 +1,5 @@
 import { SDJwtInstance } from '@sd-jwt/core';
-import { DisclosureFrame } from '@sd-jwt/types';
+import type { DisclosureFrame } from '@sd-jwt/types';
 import { createSignerVerifier, digest, generateSalt } from './utils';
 
 (async () => {

--- a/examples/sd-jwt-example/basic.ts
+++ b/examples/sd-jwt-example/basic.ts
@@ -1,5 +1,5 @@
 import { SDJwtInstance } from '@sd-jwt/core';
-import { DisclosureFrame } from '@sd-jwt/types';
+import type { DisclosureFrame } from '@sd-jwt/types';
 import { createSignerVerifier, digest, generateSalt } from './utils';
 
 (async () => {

--- a/examples/sd-jwt-example/custom.ts
+++ b/examples/sd-jwt-example/custom.ts
@@ -1,5 +1,5 @@
 import { SDJwtInstance } from '@sd-jwt/core';
-import { DisclosureFrame } from '@sd-jwt/types';
+import type { DisclosureFrame } from '@sd-jwt/types';
 import { createSignerVerifier, digest, generateSalt } from './utils';
 
 (async () => {

--- a/examples/sd-jwt-example/custom_header.ts
+++ b/examples/sd-jwt-example/custom_header.ts
@@ -1,5 +1,5 @@
 import { SDJwtInstance } from '@sd-jwt/core';
-import { DisclosureFrame } from '@sd-jwt/types';
+import type { DisclosureFrame } from '@sd-jwt/types';
 import { createSignerVerifier, digest, generateSalt } from './utils';
 
 (async () => {

--- a/examples/sd-jwt-example/decoy.ts
+++ b/examples/sd-jwt-example/decoy.ts
@@ -1,5 +1,5 @@
 import { SDJwtInstance } from '@sd-jwt/core';
-import { DisclosureFrame } from '@sd-jwt/types';
+import type { DisclosureFrame } from '@sd-jwt/types';
 import { createSignerVerifier, digest, generateSalt } from './utils';
 
 (async () => {

--- a/examples/sd-jwt-example/kb.ts
+++ b/examples/sd-jwt-example/kb.ts
@@ -1,5 +1,5 @@
 import { SDJwtInstance } from '@sd-jwt/core';
-import { DisclosureFrame } from '@sd-jwt/types';
+import type { DisclosureFrame } from '@sd-jwt/types';
 import { createSignerVerifier, digest, generateSalt } from './utils';
 
 (async () => {

--- a/examples/sd-jwt-example/sdjwtobject.ts
+++ b/examples/sd-jwt-example/sdjwtobject.ts
@@ -1,5 +1,5 @@
 import { SDJwtInstance } from '@sd-jwt/core';
-import { DisclosureFrame } from '@sd-jwt/types';
+import type { DisclosureFrame } from '@sd-jwt/types';
 import { createSignerVerifier, digest, generateSalt } from './utils';
 
 (async () => {

--- a/examples/sd-jwt-vc-example/all.ts
+++ b/examples/sd-jwt-vc-example/all.ts
@@ -1,5 +1,5 @@
 import { SDJwtVcInstance } from '@sd-jwt/sd-jwt-vc';
-import { DisclosureFrame } from '@sd-jwt/types';
+import type { DisclosureFrame } from '@sd-jwt/types';
 import { createSignerVerifier, digest, generateSalt } from './utils';
 
 (async () => {

--- a/examples/sd-jwt-vc-example/basic.ts
+++ b/examples/sd-jwt-vc-example/basic.ts
@@ -1,5 +1,5 @@
 import { SDJwtVcInstance } from '@sd-jwt/sd-jwt-vc';
-import { DisclosureFrame } from '@sd-jwt/types';
+import type { DisclosureFrame } from '@sd-jwt/types';
 import { createSignerVerifier, digest, generateSalt } from './utils';
 
 (async () => {

--- a/examples/sd-jwt-vc-example/custom.ts
+++ b/examples/sd-jwt-vc-example/custom.ts
@@ -1,5 +1,5 @@
 import { SDJwtVcInstance } from '@sd-jwt/sd-jwt-vc';
-import { DisclosureFrame } from '@sd-jwt/types';
+import type { DisclosureFrame } from '@sd-jwt/types';
 import { createSignerVerifier, digest, generateSalt } from './utils';
 
 (async () => {

--- a/examples/sd-jwt-vc-example/custom_header.ts
+++ b/examples/sd-jwt-vc-example/custom_header.ts
@@ -1,5 +1,5 @@
 import { SDJwtVcInstance } from '@sd-jwt/sd-jwt-vc';
-import { DisclosureFrame } from '@sd-jwt/types';
+import type { DisclosureFrame } from '@sd-jwt/types';
 import { createSignerVerifier, digest, generateSalt } from './utils';
 
 (async () => {

--- a/examples/sd-jwt-vc-example/decoy.ts
+++ b/examples/sd-jwt-vc-example/decoy.ts
@@ -1,5 +1,5 @@
 import { SDJwtVcInstance } from '@sd-jwt/sd-jwt-vc';
-import { DisclosureFrame } from '@sd-jwt/types';
+import type { DisclosureFrame } from '@sd-jwt/types';
 import { createSignerVerifier, digest, generateSalt } from './utils';
 
 (async () => {

--- a/examples/sd-jwt-vc-example/kb.ts
+++ b/examples/sd-jwt-vc-example/kb.ts
@@ -1,5 +1,5 @@
 import { SDJwtVcInstance } from '@sd-jwt/sd-jwt-vc';
-import { DisclosureFrame } from '@sd-jwt/types';
+import type { DisclosureFrame } from '@sd-jwt/types';
 import { createSignerVerifier, digest, generateSalt } from './utils';
 
 (async () => {

--- a/examples/sd-jwt-vc-example/sdjwtobject.ts
+++ b/examples/sd-jwt-vc-example/sdjwtobject.ts
@@ -1,5 +1,5 @@
 import { SDJwtVcInstance } from '@sd-jwt/sd-jwt-vc';
-import { DisclosureFrame } from '@sd-jwt/types';
+import type { DisclosureFrame } from '@sd-jwt/types';
 import { createSignerVerifier, digest, generateSalt } from './utils';
 
 (async () => {

--- a/package.json
+++ b/package.json
@@ -13,11 +13,7 @@
     "publish:next": "lerna publish --no-private --conventional-prerelease --force-publish --canary --no-git-tag-version --include-merged-tags --preid next --pre-dist-tag next --yes",
     "publish:unstable": "lerna publish --no-private --conventional-prerelease --force-publish --canary --no-git-tag-version --include-merged-tags --preid unstable --pre-dist-tag unstable --yes"
   },
-  "keywords": [
-    "sd-jwt",
-    "sdjwt",
-    "sd-jwt-vc"
-  ],
+  "keywords": ["sd-jwt", "sdjwt", "sd-jwt-vc"],
   "engines": {
     "node": ">=16"
   },
@@ -32,7 +28,7 @@
   },
   "license": "Apache-2.0",
   "devDependencies": {
-    "@biomejs/biome": "1.5.3",
+    "@biomejs/biome": "^1.6.0",
     "@types/node": "^20.10.2",
     "@vitest/coverage-v8": "^1.2.2",
     "jose": "^5.2.2",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "build": "lerna run build --stream",
     "lint": "biome lint ./packages",
     "format": "biome format . --write",
+    "biome:ci": "biome ci .",
     "test": "vitest run --coverage.enabled=true --coverage.include=packages/*",
     "test:watch": "vitest",
     "clean": "lerna clean -y",

--- a/packages/browser-crypto/package.json
+++ b/packages/browser-crypto/package.json
@@ -18,11 +18,7 @@
     "test:browser": "vitest run ./src/test/*.spec.ts",
     "test:cov": "vitest run --coverage"
   },
-  "keywords": [
-    "sd-jwt",
-    "sdjwt",
-    "sd-jwt-vc"
-  ],
+  "keywords": ["sd-jwt", "sdjwt", "sd-jwt-vc"],
   "repository": {
     "type": "git",
     "url": "https://github.com/openwallet-foundation-labs/sd-jwt-js"
@@ -37,17 +33,12 @@
     "access": "public"
   },
   "tsup": {
-    "entry": [
-      "./src/index.ts"
-    ],
+    "entry": ["./src/index.ts"],
     "sourceMap": true,
     "splitting": false,
     "clean": true,
     "dts": true,
-    "format": [
-      "cjs",
-      "esm"
-    ]
+    "format": ["cjs", "esm"]
   },
   "gitHead": "ded40e4551bde7ae93083181bf26bd1b38bbfcfb"
 }

--- a/packages/browser-crypto/src/test/crypto.spec.ts
+++ b/packages/browser-crypto/src/test/crypto.spec.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from 'vitest';
 import { generateSalt, digest, getHasher, ES256 } from '../index';
 
 // Extract the major version as a number
-const nodeVersionMajor = parseInt(
+const nodeVersionMajor = Number.parseInt(
   process.version.split('.')[0].substring(1),
   10,
 );

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -19,11 +19,7 @@
     "test:browser": "vitest run ./src/test/*.spec.ts --environment jsdom",
     "test:cov": "vitest run --coverage"
   },
-  "keywords": [
-    "sd-jwt",
-    "sdjwt",
-    "sd-jwt-vc"
-  ],
+  "keywords": ["sd-jwt", "sdjwt", "sd-jwt-vc"],
   "engines": {
     "node": ">=16"
   },
@@ -50,17 +46,12 @@
     "access": "public"
   },
   "tsup": {
-    "entry": [
-      "./src/index.ts"
-    ],
+    "entry": ["./src/index.ts"],
     "sourceMap": true,
     "splitting": false,
     "clean": true,
     "dts": true,
-    "format": [
-      "cjs",
-      "esm"
-    ]
+    "format": ["cjs", "esm"]
   },
   "gitHead": "ded40e4551bde7ae93083181bf26bd1b38bbfcfb"
 }

--- a/packages/core/src/decoy.ts
+++ b/packages/core/src/decoy.ts
@@ -1,4 +1,4 @@
-import { HasherAndAlg, SaltGenerator } from '@sd-jwt/types';
+import type { HasherAndAlg, SaltGenerator } from '@sd-jwt/types';
 import { Uint8ArrayToBase64Url } from '@sd-jwt/utils';
 
 // This function creates a decoy value that can be used to obscure SD JWT payload.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -3,16 +3,16 @@ import { Jwt } from './jwt';
 import { KBJwt } from './kbjwt';
 import { SDJwt, pack } from './sdjwt';
 import {
-  DisclosureFrame,
-  Hasher,
-  KBOptions,
+  type DisclosureFrame,
+  type Hasher,
+  type KBOptions,
   KB_JWT_TYP,
-  PresentationFrame,
-  SDJWTCompact,
-  SDJWTConfig,
+  type PresentationFrame,
+  type SDJWTCompact,
+  type SDJWTConfig,
 } from '@sd-jwt/types';
 import { getSDAlgAndPayload } from '@sd-jwt/decode';
-import { JwtPayload } from '@sd-jwt/types';
+import type { JwtPayload } from '@sd-jwt/types';
 
 export * from './sdjwt';
 export * from './kbjwt';

--- a/packages/core/src/jwt.ts
+++ b/packages/core/src/jwt.ts
@@ -1,5 +1,5 @@
 import { Base64urlEncode, SDJWTException } from '@sd-jwt/utils';
-import { Base64urlString, Signer, Verifier } from '@sd-jwt/types';
+import type { Base64urlString, Signer, Verifier } from '@sd-jwt/types';
 import { decodeJwt } from '@sd-jwt/decode';
 
 export type JwtData<

--- a/packages/core/src/kbjwt.ts
+++ b/packages/core/src/kbjwt.ts
@@ -1,11 +1,11 @@
 import { Base64urlEncode, SDJWTException } from '@sd-jwt/utils';
 import { Jwt } from './jwt';
 import {
-  JwtPayload,
+  type JwtPayload,
   KB_JWT_TYP,
-  kbHeader,
-  kbPayload,
-  KbVerifier,
+  type kbHeader,
+  type kbPayload,
+  type KbVerifier,
 } from '@sd-jwt/types';
 
 export class KBJwt<

--- a/packages/core/src/sdjwt.ts
+++ b/packages/core/src/sdjwt.ts
@@ -3,18 +3,18 @@ import { SDJWTException, Disclosure } from '@sd-jwt/utils';
 import { Jwt } from './jwt';
 import { KBJwt } from './kbjwt';
 import {
-  DisclosureFrame,
-  Hasher,
-  HasherAndAlg,
-  PresentationFrame,
-  SDJWTCompact,
+  type DisclosureFrame,
+  type Hasher,
+  type HasherAndAlg,
+  type PresentationFrame,
+  type SDJWTCompact,
   SD_DECOY,
   SD_DIGEST,
   SD_LIST_KEY,
   SD_SEPARATOR,
-  SaltGenerator,
-  kbHeader,
-  kbPayload,
+  type SaltGenerator,
+  type kbHeader,
+  type kbPayload,
 } from '@sd-jwt/types';
 import { createHashMapping, getSDAlgAndPayload, unpack } from '@sd-jwt/decode';
 import { transformPresentationFrame } from '@sd-jwt/present';
@@ -236,7 +236,7 @@ export const pack = async <T extends Record<string, unknown>>(
 
     for (const key in disclosureFrame) {
       if (key !== SD_DIGEST) {
-        const idx = parseInt(key);
+        const idx = Number.parseInt(key);
         const packed = await pack(
           claims[idx],
           disclosureFrame[idx],

--- a/packages/core/src/test/index.spec.ts
+++ b/packages/core/src/test/index.spec.ts
@@ -1,9 +1,9 @@
-import { SDJwtInstance, SdJwtPayload } from '../index';
-import { Signer, Verifier, KbVerifier, JwtPayload } from '@sd-jwt/types';
-import Crypto, { KeyLike } from 'node:crypto';
+import { SDJwtInstance, type SdJwtPayload } from '../index';
+import type { Signer, Verifier, KbVerifier, JwtPayload } from '@sd-jwt/types';
+import Crypto, { type KeyLike } from 'node:crypto';
 import { describe, expect, test } from 'vitest';
 import { digest, generateSalt } from '@sd-jwt/crypto-nodejs';
-import { importJWK, exportJWK, JWK } from 'jose';
+import { importJWK, exportJWK, type JWK } from 'jose';
 
 export const createSignerVerifier = () => {
   const { privateKey, publicKey } = Crypto.generateKeyPairSync('ed25519');

--- a/packages/core/src/test/jwt.spec.ts
+++ b/packages/core/src/test/jwt.spec.ts
@@ -1,7 +1,7 @@
 import { SDJWTException } from '@sd-jwt/utils';
 import { Jwt } from '../jwt';
 import Crypto from 'node:crypto';
-import { Signer, Verifier } from '@sd-jwt/types';
+import type { Signer, Verifier } from '@sd-jwt/types';
 import { describe, expect, test } from 'vitest';
 
 describe('JWT', () => {

--- a/packages/core/src/test/kbjwt.spec.ts
+++ b/packages/core/src/test/kbjwt.spec.ts
@@ -1,15 +1,15 @@
-import { SDJWTException } from '@sd-jwt/utils';
+import type { SDJWTException } from '@sd-jwt/utils';
 import { KBJwt } from '../kbjwt';
 import {
-  JwtPayload,
+  type JwtPayload,
   KB_JWT_TYP,
-  KbVerifier,
-  Signer,
+  type KbVerifier,
+  type Signer,
   Verifier,
 } from '@sd-jwt/types';
-import Crypto, { KeyLike } from 'node:crypto';
+import Crypto, { type KeyLike } from 'node:crypto';
 import { describe, expect, test } from 'vitest';
-import { JWK, exportJWK, importJWK } from 'jose';
+import { type JWK, exportJWK, importJWK } from 'jose';
 
 describe('KB JWT', () => {
   test('create', async () => {

--- a/packages/core/src/test/sdjwt.spec.ts
+++ b/packages/core/src/test/sdjwt.spec.ts
@@ -3,7 +3,7 @@ import { Jwt } from '../jwt';
 import { SDJwt, listKeys, pack } from '../sdjwt';
 import Crypto from 'node:crypto';
 import { describe, test, expect } from 'vitest';
-import { DisclosureFrame, Signer } from '@sd-jwt/types';
+import type { DisclosureFrame, Signer } from '@sd-jwt/types';
 import { generateSalt, digest as hasher } from '@sd-jwt/crypto-nodejs';
 import { unpack, createHashMapping } from '@sd-jwt/decode';
 

--- a/packages/core/test/app-e2e.spec.ts
+++ b/packages/core/test/app-e2e.spec.ts
@@ -1,13 +1,13 @@
 import Crypto from 'node:crypto';
-import { SDJwtInstance, SdJwtPayload } from '../src';
-import {
+import { SDJwtInstance, type SdJwtPayload } from '../src';
+import type {
   DisclosureFrame,
   PresentationFrame,
   Signer,
   Verifier,
 } from '@sd-jwt/types';
-import fs from 'fs';
-import path from 'path';
+import fs from 'node:fs';
+import path from 'node:path';
 import { describe, expect, test } from 'vitest';
 import { digest, generateSalt } from '@sd-jwt/crypto-nodejs';
 

--- a/packages/decode/package.json
+++ b/packages/decode/package.json
@@ -18,11 +18,7 @@
     "test:node": "vitest run ./src/test/*.spec.ts --coverage",
     "test:browser": "vitest run ./src/test/*.spec.ts --environment jsdom --coverage"
   },
-  "keywords": [
-    "sd-jwt",
-    "sdjwt",
-    "sd-jwt-vc"
-  ],
+  "keywords": ["sd-jwt", "sdjwt", "sd-jwt-vc"],
   "engines": {
     "node": ">=16"
   },
@@ -47,17 +43,12 @@
     "access": "public"
   },
   "tsup": {
-    "entry": [
-      "./src/index.ts"
-    ],
+    "entry": ["./src/index.ts"],
     "sourceMap": true,
     "splitting": false,
     "clean": true,
     "dts": true,
-    "format": [
-      "cjs",
-      "esm"
-    ]
+    "format": ["cjs", "esm"]
   },
   "gitHead": "ded40e4551bde7ae93083181bf26bd1b38bbfcfb"
 }

--- a/packages/decode/src/decode.ts
+++ b/packages/decode/src/decode.ts
@@ -1,12 +1,12 @@
 import { Base64urlDecode, SDJWTException, Disclosure } from '@sd-jwt/utils';
 import {
-  Hasher,
-  HasherAndAlg,
+  type Hasher,
+  type HasherAndAlg,
   SD_DIGEST,
   SD_LIST_KEY,
   SD_SEPARATOR,
 } from '@sd-jwt/types';
-import { HasherAndAlgSync, HasherSync } from '@sd-jwt/types/src/type';
+import type { HasherAndAlgSync, HasherSync } from '@sd-jwt/types/src/type';
 
 export const decodeJwt = <
   H extends Record<string, unknown>,

--- a/packages/hash/package.json
+++ b/packages/hash/package.json
@@ -19,11 +19,7 @@
     "test:browser": "vitest run ./src/test/*.spec.ts --environment jsdom",
     "test:cov": "vitest run --coverage"
   },
-  "keywords": [
-    "sd-jwt",
-    "sdjwt",
-    "sd-jwt-vc"
-  ],
+  "keywords": ["sd-jwt", "sdjwt", "sd-jwt-vc"],
   "engines": {
     "node": ">=16"
   },
@@ -48,17 +44,12 @@
     "access": "public"
   },
   "tsup": {
-    "entry": [
-      "./src/index.ts"
-    ],
+    "entry": ["./src/index.ts"],
     "sourceMap": true,
     "splitting": false,
     "clean": true,
     "dts": true,
-    "format": [
-      "cjs",
-      "esm"
-    ]
+    "format": ["cjs", "esm"]
   },
   "gitHead": "ded40e4551bde7ae93083181bf26bd1b38bbfcfb"
 }

--- a/packages/node-crypto/package.json
+++ b/packages/node-crypto/package.json
@@ -18,11 +18,7 @@
     "test:node": "vitest run ./src/test/*.spec.ts",
     "test:cov": "vitest run --coverage"
   },
-  "keywords": [
-    "sd-jwt",
-    "sdjwt",
-    "sd-jwt-vc"
-  ],
+  "keywords": ["sd-jwt", "sdjwt", "sd-jwt-vc"],
   "engines": {
     "node": ">=16"
   },
@@ -40,17 +36,12 @@
     "access": "public"
   },
   "tsup": {
-    "entry": [
-      "./src/index.ts"
-    ],
+    "entry": ["./src/index.ts"],
     "sourceMap": true,
     "splitting": false,
     "clean": true,
     "dts": true,
-    "format": [
-      "cjs",
-      "esm"
-    ]
+    "format": ["cjs", "esm"]
   },
   "gitHead": "ded40e4551bde7ae93083181bf26bd1b38bbfcfb"
 }

--- a/packages/node-crypto/src/crypto.ts
+++ b/packages/node-crypto/src/crypto.ts
@@ -1,4 +1,4 @@
-import { createHash, randomBytes, subtle } from 'crypto';
+import { createHash, randomBytes, subtle } from 'node:crypto';
 
 export const generateSalt = (length: number): string => {
   if (length <= 0) {

--- a/packages/node-crypto/src/test/crypto.spec.ts
+++ b/packages/node-crypto/src/test/crypto.spec.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from 'vitest';
 import { generateSalt, digest, ES256 } from '../index';
 
 // Extract the major version as a number
-const nodeVersionMajor = parseInt(
+const nodeVersionMajor = Number.parseInt(
   process.version.split('.')[0].substring(1),
   10,
 );

--- a/packages/present/package.json
+++ b/packages/present/package.json
@@ -19,11 +19,7 @@
     "test:browser": "vitest run ./src/test/*.spec.ts --environment jsdom",
     "test:cov": "vitest run --coverage"
   },
-  "keywords": [
-    "sd-jwt",
-    "sdjwt",
-    "sd-jwt-vc"
-  ],
+  "keywords": ["sd-jwt", "sdjwt", "sd-jwt-vc"],
   "engines": {
     "node": ">=16"
   },
@@ -49,17 +45,12 @@
     "access": "public"
   },
   "tsup": {
-    "entry": [
-      "./src/index.ts"
-    ],
+    "entry": ["./src/index.ts"],
     "sourceMap": true,
     "splitting": false,
     "clean": true,
     "dts": true,
-    "format": [
-      "cjs",
-      "esm"
-    ]
+    "format": ["cjs", "esm"]
   },
   "gitHead": "ded40e4551bde7ae93083181bf26bd1b38bbfcfb"
 }

--- a/packages/present/src/present.ts
+++ b/packages/present/src/present.ts
@@ -1,5 +1,9 @@
-import { Hasher, PresentationFrame, SD_SEPARATOR } from '@sd-jwt/types';
-import { Disclosure } from '@sd-jwt/utils';
+import {
+  type Hasher,
+  type PresentationFrame,
+  SD_SEPARATOR,
+} from '@sd-jwt/types';
+import type { Disclosure } from '@sd-jwt/utils';
 import {
   createHashMapping,
   decodeSdJwt,
@@ -10,7 +14,7 @@ import {
   decodeSdJwtSync,
   unpackSync,
 } from '@sd-jwt/decode';
-import { HasherSync } from '@sd-jwt/types/src/type';
+import type { HasherSync } from '@sd-jwt/types/src/type';
 
 // Presentable keys
 // The presentable keys are the path of JSON object that are presentable in the SD JWT

--- a/packages/present/src/test/present.spec.ts
+++ b/packages/present/src/test/present.spec.ts
@@ -8,7 +8,7 @@ import {
   transformPresentationFrame,
 } from '../index';
 import { decodeSdJwt, decodeSdJwtSync } from '@sd-jwt/decode';
-import { PresentationFrame } from '@sd-jwt/types';
+import type { PresentationFrame } from '@sd-jwt/types';
 
 describe('Present tests', () => {
   test('presentableKeys', async () => {

--- a/packages/sd-jwt-vc/package.json
+++ b/packages/sd-jwt-vc/package.json
@@ -20,11 +20,7 @@
     "test:e2e": "vitest run ./test/*e2e.spec.ts --environment node",
     "test:cov": "vitest run --coverage"
   },
-  "keywords": [
-    "sd-jwt",
-    "sdjwt",
-    "sd-jwt-vc"
-  ],
+  "keywords": ["sd-jwt", "sdjwt", "sd-jwt-vc"],
   "engines": {
     "node": ">=16"
   },
@@ -49,17 +45,12 @@
     "access": "public"
   },
   "tsup": {
-    "entry": [
-      "./src/index.ts"
-    ],
+    "entry": ["./src/index.ts"],
     "sourceMap": true,
     "splitting": false,
     "clean": true,
     "dts": true,
-    "format": [
-      "cjs",
-      "esm"
-    ]
+    "format": ["cjs", "esm"]
   },
   "gitHead": "ded40e4551bde7ae93083181bf26bd1b38bbfcfb"
 }

--- a/packages/sd-jwt-vc/src/index.ts
+++ b/packages/sd-jwt-vc/src/index.ts
@@ -1,7 +1,7 @@
 import { SDJwtInstance } from '@sd-jwt/core';
-import { DisclosureFrame } from '@sd-jwt/types';
+import type { DisclosureFrame } from '@sd-jwt/types';
 import { SDJWTException } from '../../utils/dist';
-import { SdJwtVcPayload } from './sd-jwt-vc-payload';
+import type { SdJwtVcPayload } from './sd-jwt-vc-payload';
 
 export { SdJwtVcPayload } from './sd-jwt-vc-payload';
 

--- a/packages/sd-jwt-vc/src/sd-jwt-vc-payload.ts
+++ b/packages/sd-jwt-vc/src/sd-jwt-vc-payload.ts
@@ -1,4 +1,4 @@
-import { SdJwtPayload } from '@sd-jwt/core';
+import type { SdJwtPayload } from '@sd-jwt/core';
 
 export interface SdJwtVcPayload extends SdJwtPayload {
   // The Issuer of the Verifiable Credential. The value of iss MUST be a URI. See [RFC7519] for more information.

--- a/packages/sd-jwt-vc/src/test/index.spec.ts
+++ b/packages/sd-jwt-vc/src/test/index.spec.ts
@@ -1,9 +1,9 @@
 import { digest, generateSalt } from '@sd-jwt/crypto-nodejs';
-import { DisclosureFrame } from '@sd-jwt/types';
+import type { DisclosureFrame } from '@sd-jwt/types';
 import { describe, test, expect } from 'vitest';
 import { SDJwtVcInstance } from '..';
 import { createSignerVerifier } from '../../test/app-e2e.spec';
-import { SdJwtVcPayload } from '../sd-jwt-vc-payload';
+import type { SdJwtVcPayload } from '../sd-jwt-vc-payload';
 
 const iss = 'ExampleIssuer';
 const vct = 'https://example.com/schema/1';

--- a/packages/sd-jwt-vc/test/app-e2e.spec.ts
+++ b/packages/sd-jwt-vc/test/app-e2e.spec.ts
@@ -1,13 +1,13 @@
 import Crypto from 'node:crypto';
 import { SDJwtVcInstance, SdJwtVcPayload } from '../src/index';
-import {
+import type {
   DisclosureFrame,
   PresentationFrame,
   Signer,
   Verifier,
 } from '@sd-jwt/types';
-import fs from 'fs';
-import path from 'path';
+import fs from 'node:fs';
+import path from 'node:path';
 import { describe, expect, test } from 'vitest';
 import { digest, generateSalt } from '@sd-jwt/crypto-nodejs';
 

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -19,11 +19,7 @@
     "test:browser": "vitest run ./src/test/*.spec.ts --environment jsdom",
     "test:cov": "vitest run --coverage"
   },
-  "keywords": [
-    "sd-jwt",
-    "sdjwt",
-    "sd-jwt-vc"
-  ],
+  "keywords": ["sd-jwt", "sdjwt", "sd-jwt-vc"],
   "engines": {
     "node": ">=16"
   },
@@ -41,17 +37,12 @@
     "access": "public"
   },
   "tsup": {
-    "entry": [
-      "./src/index.ts"
-    ],
+    "entry": ["./src/index.ts"],
     "sourceMap": true,
     "splitting": false,
     "clean": true,
     "dts": true,
-    "format": [
-      "cjs",
-      "esm"
-    ]
+    "format": ["cjs", "esm"]
   },
   "gitHead": "ded40e4551bde7ae93083181bf26bd1b38bbfcfb"
 }

--- a/packages/types/src/test/type.spec.ts
+++ b/packages/types/src/test/type.spec.ts
@@ -5,8 +5,8 @@ import {
   SD_DIGEST,
   SD_DECOY,
   KB_JWT_TYP,
-  DisclosureFrame,
-  PresentationFrame,
+  type DisclosureFrame,
+  type PresentationFrame,
 } from '../index';
 
 const claims = {

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -19,11 +19,7 @@
     "test:browser": "vitest run ./src/test/*.spec.ts --environment jsdom",
     "test:cov": "vitest run --coverage"
   },
-  "keywords": [
-    "sd-jwt",
-    "sdjwt",
-    "sd-jwt-vc"
-  ],
+  "keywords": ["sd-jwt", "sdjwt", "sd-jwt-vc"],
   "engines": {
     "node": ">=16"
   },
@@ -48,17 +44,12 @@
     "access": "public"
   },
   "tsup": {
-    "entry": [
-      "./src/index.ts"
-    ],
+    "entry": ["./src/index.ts"],
     "sourceMap": true,
     "splitting": false,
     "clean": true,
     "dts": true,
-    "format": [
-      "cjs",
-      "esm"
-    ]
+    "format": ["cjs", "esm"]
   },
   "gitHead": "ded40e4551bde7ae93083181bf26bd1b38bbfcfb"
 }

--- a/packages/utils/src/disclosure.ts
+++ b/packages/utils/src/disclosure.ts
@@ -10,7 +10,7 @@ export class Disclosure<T = unknown> {
   public salt: string;
   public key?: string;
   public value: T;
-  private _digest: string | undefined;
+  public _digest: string | undefined;
   private _encoded: string | undefined;
 
   public constructor(

--- a/packages/utils/src/disclosure.ts
+++ b/packages/utils/src/disclosure.ts
@@ -4,7 +4,11 @@ import {
   Base64urlEncode,
 } from './base64url';
 import { SDJWTException } from './error';
-import { HasherAndAlg, DisclosureData, HasherAndAlgSync } from '@sd-jwt/types';
+import type {
+  HasherAndAlg,
+  DisclosureData,
+  HasherAndAlgSync,
+} from '@sd-jwt/types';
 
 export class Disclosure<T = unknown> {
   public salt: string;

--- a/packages/utils/src/test/disclosure.spec.ts
+++ b/packages/utils/src/test/disclosure.spec.ts
@@ -1,7 +1,7 @@
 import { generateSalt, digest as hasher } from '@sd-jwt/crypto-nodejs';
 import { Disclosure } from '../disclosure';
 import { describe, expect, test } from 'vitest';
-import { Base64urlEncode, SDJWTException } from '../index';
+import { Base64urlEncode, type SDJWTException } from '../index';
 
 const hash = { alg: 'SHA256', hasher };
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     devDependencies:
       '@biomejs/biome':
-        specifier: 1.5.3
-        version: 1.5.3
+        specifier: ^1.6.0
+        version: 1.6.0
       '@types/node':
         specifier: ^20.10.2
         version: 20.11.25
@@ -284,24 +284,24 @@ packages:
     resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
     dev: true
 
-  /@biomejs/biome@1.5.3:
-    resolution: {integrity: sha512-yvZCa/g3akwTaAQ7PCwPWDCkZs3Qa5ONg/fgOUT9e6wAWsPftCjLQFPXBeGxPK30yZSSpgEmRCfpGTmVbUjGgg==}
+  /@biomejs/biome@1.6.0:
+    resolution: {integrity: sha512-hvP8K1+CV8qc9eNdXtPwzScVxFSHB448CPKSqX6+8IW8G7bbhBVKGC80BowExJN5+vu+kzsj4xkWa780MAOlJw==}
     engines: {node: '>=14.*'}
     hasBin: true
     requiresBuild: true
     optionalDependencies:
-      '@biomejs/cli-darwin-arm64': 1.5.3
-      '@biomejs/cli-darwin-x64': 1.5.3
-      '@biomejs/cli-linux-arm64': 1.5.3
-      '@biomejs/cli-linux-arm64-musl': 1.5.3
-      '@biomejs/cli-linux-x64': 1.5.3
-      '@biomejs/cli-linux-x64-musl': 1.5.3
-      '@biomejs/cli-win32-arm64': 1.5.3
-      '@biomejs/cli-win32-x64': 1.5.3
+      '@biomejs/cli-darwin-arm64': 1.6.0
+      '@biomejs/cli-darwin-x64': 1.6.0
+      '@biomejs/cli-linux-arm64': 1.6.0
+      '@biomejs/cli-linux-arm64-musl': 1.6.0
+      '@biomejs/cli-linux-x64': 1.6.0
+      '@biomejs/cli-linux-x64-musl': 1.6.0
+      '@biomejs/cli-win32-arm64': 1.6.0
+      '@biomejs/cli-win32-x64': 1.6.0
     dev: true
 
-  /@biomejs/cli-darwin-arm64@1.5.3:
-    resolution: {integrity: sha512-ImU7mh1HghEDyqNmxEZBoMPr8SxekkZuYcs+gynKlNW+TALQs7swkERiBLkG9NR0K1B3/2uVzlvYowXrmlW8hw==}
+  /@biomejs/cli-darwin-arm64@1.6.0:
+    resolution: {integrity: sha512-K1Fjqye5pt+Ua+seC7V/2bFjfnqOaEOcQbBQSiiefB/VPNOb6lA5NFIfJ1PskTA3JrMXE1k7iqKQn56qrKFS6A==}
     engines: {node: '>=14.*'}
     cpu: [arm64]
     os: [darwin]
@@ -309,8 +309,8 @@ packages:
     dev: true
     optional: true
 
-  /@biomejs/cli-darwin-x64@1.5.3:
-    resolution: {integrity: sha512-vCdASqYnlpq/swErH7FD6nrFz0czFtK4k/iLgj0/+VmZVjineFPgevOb+Sr9vz0tk0GfdQO60bSpI74zU8M9Dw==}
+  /@biomejs/cli-darwin-x64@1.6.0:
+    resolution: {integrity: sha512-CjEALu6vN9RbcfhaBDoj481mesUIsUjxgQn+/kiMCea+Paypqslhez1I7OwRBJnkzz+Pa+PXdABd7S30eyy6+Q==}
     engines: {node: '>=14.*'}
     cpu: [x64]
     os: [darwin]
@@ -318,8 +318,8 @@ packages:
     dev: true
     optional: true
 
-  /@biomejs/cli-linux-arm64-musl@1.5.3:
-    resolution: {integrity: sha512-DYuMizUYUBYfS0IHGjDrOP1RGipqWfMGEvNEJ398zdtmCKLXaUvTimiox5dvx4X15mBK5M2m8wgWUgOP1giUpQ==}
+  /@biomejs/cli-linux-arm64-musl@1.6.0:
+    resolution: {integrity: sha512-prww6AUuJ+IO/GziN3WjtGM/DNOVuPFxqWrK97wKTZygEDdA+o1qHUN2HeCkSyk084xnzbMSbls5xscAKAn43A==}
     engines: {node: '>=14.*'}
     cpu: [arm64]
     os: [linux]
@@ -327,8 +327,8 @@ packages:
     dev: true
     optional: true
 
-  /@biomejs/cli-linux-arm64@1.5.3:
-    resolution: {integrity: sha512-cupBQv0sNF1OKqBfx7EDWMSsKwRrBUZfjXawT4s6hKV6ALq7p0QzWlxr/sDmbKMLOaLQtw2Qgu/77N9rm+f9Rg==}
+  /@biomejs/cli-linux-arm64@1.6.0:
+    resolution: {integrity: sha512-32LVrC7dAgQT39YZ0ieO/VzzpAflozs9mW5K0oKNef7S4ocCdk89E98eXApxOdei0JTf3vfseDCl1AUIp6MwJw==}
     engines: {node: '>=14.*'}
     cpu: [arm64]
     os: [linux]
@@ -336,8 +336,8 @@ packages:
     dev: true
     optional: true
 
-  /@biomejs/cli-linux-x64-musl@1.5.3:
-    resolution: {integrity: sha512-UUHiAnlDqr2Y/LpvshBFhUYMWkl2/Jn+bi3U6jKuav0qWbbBKU/ByHgR4+NBxpKBYoCtWxhnmatfH1bpPIuZMw==}
+  /@biomejs/cli-linux-x64-musl@1.6.0:
+    resolution: {integrity: sha512-NwitWeUKCy8G/rr+rgHPYirnrsOjJEJBWODdaRzweeFNcJjvO6de6AmNdSJzsewzLEaxjOWyoXU03MdzbGz/6Q==}
     engines: {node: '>=14.*'}
     cpu: [x64]
     os: [linux]
@@ -345,8 +345,8 @@ packages:
     dev: true
     optional: true
 
-  /@biomejs/cli-linux-x64@1.5.3:
-    resolution: {integrity: sha512-YQrSArQvcv4FYsk7Q91Yv4uuu5F8hJyORVcv3zsjCLGkjIjx2RhjYLpTL733SNL7v33GmOlZY0eFR1ko38tuUw==}
+  /@biomejs/cli-linux-x64@1.6.0:
+    resolution: {integrity: sha512-b6mWu9Cu4w5B3K46wq9SlxKEZEEL6II/6HFNAuZ4YL8mOeQ0FTMU+wNMJFKkmkSE2zvim3xwW3PknmbLKbe3Mg==}
     engines: {node: '>=14.*'}
     cpu: [x64]
     os: [linux]
@@ -354,8 +354,8 @@ packages:
     dev: true
     optional: true
 
-  /@biomejs/cli-win32-arm64@1.5.3:
-    resolution: {integrity: sha512-HxatYH7vf/kX9nrD+pDYuV2GI9GV8EFo6cfKkahAecTuZLPxryHx1WEfJthp5eNsE0+09STGkKIKjirP0ufaZA==}
+  /@biomejs/cli-win32-arm64@1.6.0:
+    resolution: {integrity: sha512-DlNOL6mG+76iZS1gL/UiuMme7jnt+auzo2+u0aUq6UXYsb75juchwlnVLy2UV5CQjVBRB8+RM+KVoXRZ8NlBjQ==}
     engines: {node: '>=14.*'}
     cpu: [arm64]
     os: [win32]
@@ -363,8 +363,8 @@ packages:
     dev: true
     optional: true
 
-  /@biomejs/cli-win32-x64@1.5.3:
-    resolution: {integrity: sha512-fMvbSouZEASU7mZH8SIJSANDm5OqsjgtVXlbUqxwed6BP7uuHRSs396Aqwh2+VoW8fwTpp6ybIUoC9FrzB0kyA==}
+  /@biomejs/cli-win32-x64@1.6.0:
+    resolution: {integrity: sha512-sXBcXIOGuG8/XcHqmnkhLIs0oy6Dp+TkH4Alr4WH/P8mNsp5GcStI/ZwbEiEoxA0P3Fi+oUppQ6srxaY2rSCHg==}
     engines: {node: '>=14.*'}
     cpu: [x64]
     os: [win32]


### PR DESCRIPTION
I made _digest value in disclosure as public. 

When implementing features in holder side, usually we decode the disclosures and make a logic. In this situation we normally have _digest value, not need to calculate. So delivering hasher to get _digest value is not necessary.

It closes #150  