### PR TITLE
feat: set token for deployment

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -170,7 +170,7 @@ jobs:
 
       - name: 'Setup git coordinates'
         run: |
-          git remote set-url origin https://${{github.actor}}:${{secrets.GITHUB_TOKEN}}@github.com/${{ github.repository }}.git
+          git remote set-url origin https://${{github.actor}}:${{secrets.TOKEN}}@github.com/${{ github.repository }}.git
           git config user.name $GH_USER
           git config user.email $GH_EMAIL
 


### PR DESCRIPTION
The release workflow will update the code by writing a new version number to the files. But since we have a protection rule on the main branch, we can not push directly. So the solution is to use a personal github token where the user is authorised to bypass the call.

In the future it would be better to use an app for this, see this discussion.
https://github.com/orgs/community/discussions/13836