### PR TITLE
fix(sd-jwt-vc): improve alignment with draft-03

### DIFF
--- a/packages/sd-jwt-vc/src/index.ts
+++ b/packages/sd-jwt-vc/src/index.ts
@@ -9,7 +9,7 @@ export class SDJwtVcInstance extends SDJwtInstance<SdJwtVcPayload> {
   /**
    * The type of the SD-JWT-VC set in the header.typ field.
    */
-  protected type = 'sd-jwt-vc';
+  protected type = 'vc+sd-jwt';
 
   /**
    * Validates if the disclosureFrame contains any reserved fields. If so it will throw an error.
@@ -18,21 +18,13 @@ export class SDJwtVcInstance extends SDJwtInstance<SdJwtVcPayload> {
   protected validateReservedFields(
     disclosureFrame: DisclosureFrame<SdJwtVcPayload>,
   ): void {
-    //validate disclosureFrame according to https://www.ietf.org/archive/id/draft-ietf-oauth-sd-jwt-vc-01.html#section-3.2.2.2
+    //validate disclosureFrame according to https://www.ietf.org/archive/id/draft-ietf-oauth-sd-jwt-vc-03.html#section-3.2.2.2
     if (
       disclosureFrame?._sd &&
       Array.isArray(disclosureFrame._sd) &&
       disclosureFrame._sd.length > 0
     ) {
-      const reservedNames = [
-        'iss',
-        'iat',
-        'nbf',
-        'exp',
-        'cnf',
-        'vct',
-        'status',
-      ];
+      const reservedNames = ['iss', 'nbf', 'exp', 'cnf', 'vct', 'status'];
       // check if there is any reserved names in the disclosureFrame._sd array
       const reservedNamesInDisclosureFrame = (
         disclosureFrame._sd as string[]

--- a/packages/sd-jwt-vc/src/sd-jwt-vc-payload.ts
+++ b/packages/sd-jwt-vc/src/sd-jwt-vc-payload.ts
@@ -1,21 +1,21 @@
 import type { SdJwtPayload } from '@sd-jwt/core';
 
 export interface SdJwtVcPayload extends SdJwtPayload {
-  // The Issuer of the Verifiable Credential. The value of iss MUST be a URI. See [RFC7519] for more information.
+  // REQUIRED. The Issuer of the Verifiable Credential. The value of iss MUST be a URI. See [RFC7519] for more information.
   iss: string;
-  // The time of issuance of the Verifiable Credential. See [RFC7519] for more information.
-  iat: number;
   // OPTIONAL. The time before which the Verifiable Credential MUST NOT be accepted before validating. See [RFC7519] for more information.
   nbf?: number;
-  //OPTIONAL. The expiry time of the Verifiable Credential after which the Verifiable Credential is no longer valid. See [RFC7519] for more information.
+  // OPTIONAL. The expiry time of the Verifiable Credential after which the Verifiable Credential is no longer valid. See [RFC7519] for more information.
   exp?: number;
-  // REQUIRED when Cryptographic Key Binding is to be supported. Contains the confirmation method as defined in [RFC7800]. It is RECOMMENDED that this contains a JWK as defined in Section 3.2 of [RFC7800]. For Cryptographic Key Binding, the Key Binding JWT in the Combined Format for Presentation MUST be signed by the key identified in this claim.
+  // OPTIONAL unless cryptographic Key Binding is to be supported, in which case it is REQUIRED. Contains the confirmation method identifying the proof of possession key as defined in [RFC7800]. It is RECOMMENDED that this contains a JWK as defined in Section 3.2 of [RFC7800]. For proof of cryptographic Key Binding, the Key Binding JWT in the presentation of the SD-JWT MUST be signed by the key identified in this claim.
   cnf?: unknown;
-  //REQUIRED. The type of the Verifiable Credential, e.g., https://credentials.example.com/identity_credential, as defined in Section 3.2.2.1.1.
+  // REQUIRED. The type of the Verifiable Credential, e.g., https://credentials.example.com/identity_credential, as defined in Section 3.2.2.1.1.
   vct: string;
   // OPTIONAL. The information on how to read the status of the Verifiable Credential. See [I-D.looker-oauth-jwt-cwt-status-list] for more information.
   status?: unknown;
 
-  //The identifier of the Subject of the Verifiable Credential. The Issuer MAY use it to provide the Subject identifier known by the Issuer. There is no requirement for a binding to exist between sub and cnf claims.
+  // OPTIONAL. The identifier of the Subject of the Verifiable Credential. The Issuer MAY use it to provide the Subject identifier known by the Issuer. There is no requirement for a binding to exist between sub and cnf claims.
   sub?: string;
+  // OPTIONAL. The time of issuance of the Verifiable Credential. See [RFC7519] for more information.
+  iat?: number;
 }

--- a/packages/sd-jwt-vc/test/app-e2e.spec.ts
+++ b/packages/sd-jwt-vc/test/app-e2e.spec.ts
@@ -232,7 +232,7 @@ async function JSONtest(filename: string) {
 
   expect(validated).toBeDefined();
   expect(validated).toStrictEqual({
-    header: { alg: 'EdDSA', typ: 'sd-jwt-vc' },
+    header: { alg: 'EdDSA', typ: 'vc+sd-jwt' },
     payload,
   });
 
@@ -256,7 +256,7 @@ async function JSONtest(filename: string) {
 
   expect(verified).toBeDefined();
   expect(verified).toStrictEqual({
-    header: { alg: 'EdDSA', typ: 'sd-jwt-vc' },
+    header: { alg: 'EdDSA', typ: 'vc+sd-jwt' },
     payload,
   });
 }


### PR DESCRIPTION
Improves alignment with draft 03
- iat is no longer required
- iat can now be selective disclosed
- the header.typ value is now vc+sd-jwt