### PR TITLE
Fix/pass types

### DIFF
--- a/examples/sd-jwt-example/all.ts
+++ b/examples/sd-jwt-example/all.ts
@@ -92,7 +92,10 @@ import { createSignerVerifier, digest, generateSalt } from './utils';
 
   // Create a presentation using the issued credential and the presentation frame
   // return a Encoded SD JWT. Holder send the presentation to the verifier
-  const presentation = await sdjwt.present(credential, presentationFrame);
+  const presentation = await sdjwt.present<typeof claims>(
+    credential,
+    presentationFrame,
+  );
   console.log('presentedSDJwt:', presentation);
 
   // Verifier Define the required claims that need to be verified in the presentation

--- a/examples/sd-jwt-example/basic.ts
+++ b/examples/sd-jwt-example/basic.ts
@@ -43,7 +43,10 @@ import { createSignerVerifier, digest, generateSalt } from './utils';
 
   // Create a presentation using the issued credential and the presentation frame
   // return a Encoded SD JWT. Holder send the presentation to the verifier
-  const presentation = await sdjwt.present(credential, presentationFrame);
+  const presentation = await sdjwt.present<typeof claims>(
+    credential,
+    presentationFrame,
+  );
 
   // Verifier Define the required claims that need to be verified in the presentation
   const requiredClaims = ['firstname', 'ssn', 'id'];

--- a/examples/sd-jwt-example/custom.ts
+++ b/examples/sd-jwt-example/custom.ts
@@ -69,7 +69,10 @@ import { createSignerVerifier, digest, generateSalt } from './utils';
 
   // Create a presentation using the issued credential and the presentation frame
   // return a Encoded SD JWT. Holder send the presentation to the verifier
-  const presentation = await sdjwt.present(credential, presentationFrame);
+  const presentation = await sdjwt.present<typeof claims>(
+    credential,
+    presentationFrame,
+  );
   console.log('presentedSDJwt:', presentation);
 
   // Verifier Define the required claims that need to be verified in the presentation

--- a/examples/sd-jwt-example/kb.ts
+++ b/examples/sd-jwt-example/kb.ts
@@ -38,7 +38,7 @@ import { createSignerVerifier, digest, generateSalt } from './utils';
   const sdjwttoken = await sdjwt.decode(encodedSdjwt);
   console.log(sdjwttoken);
 
-  const presentedSdJwt = await sdjwt.present(
+  const presentedSdJwt = await sdjwt.present<typeof claims>(
     encodedSdjwt,
     { id: true },
     {

--- a/examples/sd-jwt-vc-example/all.ts
+++ b/examples/sd-jwt-vc-example/all.ts
@@ -100,7 +100,10 @@ import { createSignerVerifier, digest, generateSalt } from './utils';
 
   // Create a presentation using the issued credential and the presentation frame
   // return a Encoded SD JWT. Holder send the presentation to the verifier
-  const presentation = await sdjwt.present(credential, presentationFrame);
+  const presentation = await sdjwt.present<typeof claims>(
+    credential,
+    presentationFrame,
+  );
   console.log('presentedSDJwt:', presentation);
 
   // Verifier Define the required claims that need to be verified in the presentation

--- a/examples/sd-jwt-vc-example/basic.ts
+++ b/examples/sd-jwt-vc-example/basic.ts
@@ -51,7 +51,10 @@ import { createSignerVerifier, digest, generateSalt } from './utils';
 
   // Create a presentation using the issued credential and the presentation frame
   // return a Encoded SD JWT. Holder send the presentation to the verifier
-  const presentation = await sdjwt.present(credential, presentationFrame);
+  const presentation = await sdjwt.present<typeof claims>(
+    credential,
+    presentationFrame,
+  );
 
   // Verifier Define the required claims that need to be verified in the presentation
   const requiredClaims = ['firstname', 'ssn', 'id'];

--- a/examples/sd-jwt-vc-example/custom.ts
+++ b/examples/sd-jwt-vc-example/custom.ts
@@ -77,7 +77,10 @@ import { createSignerVerifier, digest, generateSalt } from './utils';
 
   // Create a presentation using the issued credential and the presentation frame
   // return a Encoded SD JWT. Holder send the presentation to the verifier
-  const presentation = await sdjwt.present(credential, presentationFrame);
+  const presentation = await sdjwt.present<typeof claims>(
+    credential,
+    presentationFrame,
+  );
   console.log('presentedSDJwt:', presentation);
 
   // Verifier Define the required claims that need to be verified in the presentation

--- a/examples/sd-jwt-vc-example/kb.ts
+++ b/examples/sd-jwt-vc-example/kb.ts
@@ -46,7 +46,7 @@ import { createSignerVerifier, digest, generateSalt } from './utils';
   const sdjwttoken = await sdjwt.decode(encodedSdjwt);
   console.log(sdjwttoken);
 
-  const presentedSdJwt = await sdjwt.present(
+  const presentedSdJwt = await sdjwt.present<typeof claims>(
     encodedSdjwt,
     { id: true },
     {

--- a/packages/core/src/test/index.spec.ts
+++ b/packages/core/src/test/index.spec.ts
@@ -59,7 +59,7 @@ describe('index', () => {
 
     expect(credential).toBeDefined();
 
-    const presentation = await sdjwt.present(
+    const presentation = await sdjwt.present<typeof claims>(
       credential,
       { foo: true },
       {
@@ -173,7 +173,7 @@ describe('index', () => {
       },
     );
 
-    const presentation = await sdjwt.present(
+    const presentation = await sdjwt.present<typeof claims>(
       credential,
       { foo: true },
       {
@@ -249,7 +249,7 @@ describe('index', () => {
       },
     );
 
-    const presentation = await sdjwt.present(
+    const presentation = await sdjwt.present<typeof claims>(
       credential,
       { foo: true },
       {
@@ -359,7 +359,7 @@ describe('index', () => {
       },
     );
 
-    const presentation = await sdjwt.present(
+    const presentation = await sdjwt.present<typeof claims>(
       credential,
       { foo: true },
       {
@@ -403,7 +403,7 @@ describe('index', () => {
       },
     );
     try {
-      const presentation = await sdjwt.present(
+      const presentation = await sdjwt.present<typeof claims>(
         credential,
         { foo: true },
         {
@@ -445,7 +445,7 @@ describe('index', () => {
       },
     );
 
-    const presentation = await sdjwt.present(
+    const presentation = await sdjwt.present<typeof claims>(
       credential,
       { foo: true },
       {
@@ -488,7 +488,7 @@ describe('index', () => {
       },
     );
 
-    const presentation = sdjwt.present(
+    const presentation = sdjwt.present<typeof claims>(
       credential,
       { foo: true },
       {
@@ -530,9 +530,9 @@ describe('index', () => {
     expect(sdjwt.presentableKeys('')).rejects.toThrow('Hasher not found');
     expect(sdjwt.getClaims('')).rejects.toThrow('Hasher not found');
     expect(() => sdjwt.decode('')).toThrowError('Hasher not found');
-    expect(sdjwt.present(credential, { foo: true })).rejects.toThrow(
-      'Hasher not found',
-    );
+    expect(
+      sdjwt.present<typeof claims>(credential, { foo: true }),
+    ).rejects.toThrow('Hasher not found');
   });
 
   test('presentableKeys', async () => {
@@ -581,15 +581,19 @@ describe('index', () => {
       },
     );
 
-    const presentation = await sdjwt.present(credential, undefined, {
-      kb: {
-        payload: {
-          aud: '1',
-          iat: 1,
-          nonce: '342',
+    const presentation = await sdjwt.present<typeof claims>(
+      credential,
+      undefined,
+      {
+        kb: {
+          payload: {
+            aud: '1',
+            iat: 1,
+            nonce: '342',
+          },
         },
       },
-    });
+    );
 
     const decoded = await sdjwt.decode(presentation);
     expect(decoded.jwt).toBeDefined();

--- a/packages/core/test/app-e2e.spec.ts
+++ b/packages/core/test/app-e2e.spec.ts
@@ -114,7 +114,10 @@ describe('App', () => {
       firstname: true,
       id: true,
     };
-    const presentedSDJwt = await sdjwt.present(encodedSdjwt, presentationFrame);
+    const presentedSDJwt = await sdjwt.present<typeof claims>(
+      encodedSdjwt,
+      presentationFrame,
+    );
     expect(presentedSDJwt).toBeDefined();
 
     const presentationClaims = await sdjwt.getClaims(presentedSDJwt);
@@ -221,7 +224,7 @@ async function JSONtest(filename: string) {
     payload: test.claims,
   });
 
-  const presentedSDJwt = await sdjwt.present(
+  const presentedSDJwt = await sdjwt.present<typeof claims>(
     encodedSdjwt,
     test.presentationFrames,
   );

--- a/packages/present/src/present.ts
+++ b/packages/present/src/present.ts
@@ -114,13 +114,18 @@ export const presentSync = <T extends Record<string, unknown>>(
 };
 
 /**
+ * Type of a frame that is used to present the SD JWT
+ */
+type Frame = Record<string, boolean | unknown>;
+
+/**
  * Transform the object keys into an array of strings. We are not sorting the array in any way.
  * @param obj The object to transform
  * @param prefix The prefix to add to the keys
  * @returns
  */
-export const transformPresentationFrame = <T extends object>(
-  obj: PresentationFrame<T>,
+export const transformPresentationFrame = (
+  obj: PresentationFrame<Frame>,
   prefix = '',
 ): string[] => {
   return Object.entries(obj).reduce<string[]>((acc, [key, value]) => {
@@ -130,10 +135,13 @@ export const transformPresentationFrame = <T extends object>(
       if (value) {
         acc.push(newPrefix);
       }
-    } else {
+    } else if (typeof value === 'object' && value !== null) {
       acc.push(
         newPrefix,
-        ...transformPresentationFrame(value as PresentationFrame<T>, newPrefix),
+        ...transformPresentationFrame(
+          value as PresentationFrame<Frame>,
+          newPrefix,
+        ),
       );
     }
     return acc;

--- a/packages/present/src/present.ts
+++ b/packages/present/src/present.ts
@@ -114,18 +114,13 @@ export const presentSync = <T extends Record<string, unknown>>(
 };
 
 /**
- * Type of a frame that is used to present the SD JWT
- */
-type Frame = Record<string, boolean | unknown>;
-
-/**
  * Transform the object keys into an array of strings. We are not sorting the array in any way.
  * @param obj The object to transform
  * @param prefix The prefix to add to the keys
  * @returns
  */
 export const transformPresentationFrame = (
-  obj: PresentationFrame<Frame>,
+  obj: PresentationFrame<Extensible>,
   prefix = '',
 ): string[] => {
   return Object.entries(obj).reduce<string[]>((acc, [key, value]) => {
@@ -139,7 +134,7 @@ export const transformPresentationFrame = (
       acc.push(
         newPrefix,
         ...transformPresentationFrame(
-          value as PresentationFrame<Frame>,
+          value as PresentationFrame<Extensible>,
           newPrefix,
         ),
       );

--- a/packages/present/src/present.ts
+++ b/packages/present/src/present.ts
@@ -15,7 +15,7 @@ import {
   unpackSync,
   unpackObj,
 } from '@sd-jwt/decode';
-import type { HasherSync } from '@sd-jwt/types/src/type';
+import type { Extensible, HasherSync } from '@sd-jwt/types/src/type';
 
 // Presentable keys
 // The presentable keys are the path of JSON object that are presentable in the SD JWT

--- a/packages/sd-jwt-vc/test/app-e2e.spec.ts
+++ b/packages/sd-jwt-vc/test/app-e2e.spec.ts
@@ -125,7 +125,10 @@ describe('App', () => {
       firstname: true,
       id: true,
     };
-    const presentedSDJwt = await sdjwt.present(encodedSdjwt, presentationFrame);
+    const presentedSDJwt = await sdjwt.present<typeof claims>(
+      encodedSdjwt,
+      presentationFrame,
+    );
     expect(presentedSDJwt).toBeDefined();
 
     const presentationClaims = await sdjwt.getClaims(presentedSDJwt);
@@ -236,7 +239,7 @@ async function JSONtest(filename: string) {
     payload,
   });
 
-  const presentedSDJwt = await sdjwt.present(
+  const presentedSDJwt = await sdjwt.present<typeof claims>(
     encodedSdjwt,
     test.presentationFrames,
   );

--- a/packages/types/src/type.ts
+++ b/packages/types/src/type.ts
@@ -153,7 +153,10 @@ type Frame<Payload> = Payload extends Array<infer U>
       >
     : SD<Payload> & DECOY;
 
-export type Extensible = Record<string, unknown>;
+/**
+ * This is a disclosureFrame type that is used to represent the structure of what is being disclosed.
+ */
+export type Extensible = Record<string, unknown | boolean>;
 
 export type DisclosureFrame<T extends Extensible> = Frame<T>;
 

--- a/packages/types/src/type.ts
+++ b/packages/types/src/type.ts
@@ -143,17 +143,19 @@ type Frame<Payload> = Payload extends Array<infer U>
     ? Record<number, Frame<U>> & SD<Payload> & DECOY
     : SD<Payload> & DECOY
   : Payload extends Record<string, unknown>
-    ? NonNever<
-        {
-          [K in keyof Payload]?: Payload[K] extends object
-            ? Frame<Payload[K]>
-            : never;
-        } & SD<Payload> &
-          DECOY
-      >
-    : SD<Payload> & DECOY;
+  ? NonNever<
+      {
+        [K in keyof Payload]?: Payload[K] extends object
+          ? Frame<Payload[K]>
+          : never;
+      } & SD<Payload> &
+        DECOY
+    >
+  : SD<Payload> & DECOY;
 
-export type DisclosureFrame<T extends object> = Frame<T>;
+export type Extensible = Record<string, unknown>;
+
+export type DisclosureFrame<T extends Extensible> = Frame<T>;
 
 /**
  * This is a presentationFrame type that is used to represent the structure of what is being presented.
@@ -208,4 +210,4 @@ type PFrame<Payload> = Payload extends Array<infer U>
         : boolean;
     };
 
-export type PresentationFrame<T extends object> = PFrame<T>;
+export type PresentationFrame<T extends Extensible> = PFrame<T>;

--- a/packages/types/src/type.ts
+++ b/packages/types/src/type.ts
@@ -143,15 +143,15 @@ type Frame<Payload> = Payload extends Array<infer U>
     ? Record<number, Frame<U>> & SD<Payload> & DECOY
     : SD<Payload> & DECOY
   : Payload extends Record<string, unknown>
-  ? NonNever<
-      {
-        [K in keyof Payload]?: Payload[K] extends object
-          ? Frame<Payload[K]>
-          : never;
-      } & SD<Payload> &
-        DECOY
-    >
-  : SD<Payload> & DECOY;
+    ? NonNever<
+        {
+          [K in keyof Payload]?: Payload[K] extends object
+            ? Frame<Payload[K]>
+            : never;
+        } & SD<Payload> &
+          DECOY
+      >
+    : SD<Payload> & DECOY;
 
 export type Extensible = Record<string, unknown>;
 


### PR DESCRIPTION
- passes the type of claims to the present function. This makes sure in case the variable `presentationFrame` was initialised without a type.
- removes the object type from the transform function