### PR TITLE
doc: change link to main branch

### DIFF
--- a/packages/browser-crypto/README.md
+++ b/packages/browser-crypto/README.md
@@ -32,7 +32,7 @@ Ensure you have Node.js installed as a prerequisite.
 
 ### Usage
 
-Check out more details in our [documentation](https://github.com/openwallet-foundation-labs/sd-jwt-js/tree/next/docs) or [examples](https://github.com/openwallet-foundation-labs/sd-jwt-js/tree/next/examples)
+Check out more details in our [documentation](https://github.com/openwallet-foundation-labs/sd-jwt-js/tree/main/docs) or [examples](https://github.com/openwallet-foundation-labs/sd-jwt-js/tree/main/examples)
 
 ### Dependencies
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -32,11 +32,12 @@ Ensure you have Node.js installed as a prerequisite.
 
 ### Usage
 
-The library can be used to create sd-jwt based credentials. To be compliant with the  `sd-jwt-vc` standard, you can use the `@sd-jwt/sd-jwt-vc` that is implementing this spec.
+The library can be used to create sd-jwt based credentials. To be compliant with the `sd-jwt-vc` standard, you can use the `@sd-jwt/sd-jwt-vc` that is implementing this spec.
 If you want to use the pure sd-jwt class or implement your own sd-jwt credential approach, you can use this library.
 
 ### Dependencies
 
 - @sd-jwt/decode
+- @sd-jwt/present
 - @sd-jwt/types
 - @sd-jwt/utils

--- a/packages/decode/README.md
+++ b/packages/decode/README.md
@@ -32,7 +32,7 @@ Ensure you have Node.js installed as a prerequisite.
 
 ### Usage
 
-Check out more details in our [documentation](https://github.com/openwallet-foundation-labs/sd-jwt-js/tree/next/docs) or [examples](https://github.com/openwallet-foundation-labs/sd-jwt-js/tree/next/examples)
+Check out more details in our [documentation](https://github.com/openwallet-foundation-labs/sd-jwt-js/tree/main/docs) or [examples](https://github.com/openwallet-foundation-labs/sd-jwt-js/tree/main/examples)
 
 ### Dependencies
 

--- a/packages/hash/README.md
+++ b/packages/hash/README.md
@@ -32,7 +32,7 @@ Ensure you have Node.js installed as a prerequisite.
 
 ### Usage
 
-Check out more details in our [documentation](https://github.com/openwallet-foundation-labs/sd-jwt-js/tree/next/docs) or [examples](https://github.com/openwallet-foundation-labs/sd-jwt-js/tree/next/examples)
+Check out more details in our [documentation](https://github.com/openwallet-foundation-labs/sd-jwt-js/tree/main/docs) or [examples](https://github.com/openwallet-foundation-labs/sd-jwt-js/tree/main/examples)
 
 ### Dependencies
 

--- a/packages/node-crypto/README.md
+++ b/packages/node-crypto/README.md
@@ -32,7 +32,7 @@ Ensure you have Node.js installed as a prerequisite.
 
 ### Usage
 
-Check out more details in our [documentation](https://github.com/openwallet-foundation-labs/sd-jwt-js/tree/next/docs) or [examples](https://github.com/openwallet-foundation-labs/sd-jwt-js/tree/next/examples)
+Check out more details in our [documentation](https://github.com/openwallet-foundation-labs/sd-jwt-js/tree/main/docs) or [examples](https://github.com/openwallet-foundation-labs/sd-jwt-js/tree/main/examples)
 
 ### Dependencies
 

--- a/packages/present/README.md
+++ b/packages/present/README.md
@@ -32,7 +32,7 @@ Ensure you have Node.js installed as a prerequisite.
 
 ### Usage
 
-Check out more details in our [documentation](https://github.com/openwallet-foundation-labs/sd-jwt-js/tree/next/docs) or [examples](https://github.com/openwallet-foundation-labs/sd-jwt-js/tree/next/examples)
+Check out more details in our [documentation](https://github.com/openwallet-foundation-labs/sd-jwt-js/tree/main/docs) or [examples](https://github.com/openwallet-foundation-labs/sd-jwt-js/tree/main/examples)
 
 ### Dependencies
 

--- a/packages/sd-jwt-vc/README.md
+++ b/packages/sd-jwt-vc/README.md
@@ -38,13 +38,13 @@ Here's a basic example of how to use this library:
 import { DisclosureFrame } from '@sd-jwt/sd-jwt-vc';
 
 // identifier of the issuer
-const iss = "University";
+const iss = 'University';
 
 // issuance time
 const iat = new Date().getTime() / 1000;
 
 //unique identifier of the schema
-const vct = "University-Degree";
+const vct = 'University-Degree';
 
 // Issuer defines the claims object with the user's information
 const claims = {
@@ -61,7 +61,10 @@ const disclosureFrame: DisclosureFrame<typeof claims> = {
 
 // Issuer issues a signed JWT credential with the specified claims and disclosure frame
 // returns an encoded JWT
-const credential = await sdjwt.issue({iss, iat, vct, ...claims}, disclosureFrame);
+const credential = await sdjwt.issue(
+  { iss, iat, vct, ...claims },
+  disclosureFrame,
+);
 
 // Holder may validate the credential from the issuer
 const valid = await sdjwt.validate(credential);
@@ -78,7 +81,7 @@ const presentation = await sdjwt.present(credential, presentationFrame);
 const verified = await sdjwt.verify(presentation);
 ```
 
-Check out more details in our [documentation](https://github.com/openwallet-foundation-labs/sd-jwt-js/tree/next/docs) or [examples](https://github.com/openwallet-foundation-labs/sd-jwt-js/tree/next/examples)
+Check out more details in our [documentation](https://github.com/openwallet-foundation-labs/sd-jwt-js/tree/main/docs) or [examples](https://github.com/openwallet-foundation-labs/sd-jwt-js/tree/main/examples)
 
 ### Dependencies
 

--- a/packages/types/README.md
+++ b/packages/types/README.md
@@ -32,7 +32,7 @@ Ensure you have Node.js installed as a prerequisite.
 
 ### Usage
 
-Check out more details in our [documentation](https://github.com/openwallet-foundation-labs/sd-jwt-js/tree/next/docs) or [examples](https://github.com/openwallet-foundation-labs/sd-jwt-js/tree/next/examples)
+Check out more details in our [documentation](https://github.com/openwallet-foundation-labs/sd-jwt-js/tree/main/docs) or [examples](https://github.com/openwallet-foundation-labs/sd-jwt-js/tree/main/examples)
 
 ### Dependencies
 

--- a/packages/utils/README.md
+++ b/packages/utils/README.md
@@ -32,7 +32,7 @@ Ensure you have Node.js installed as a prerequisite.
 
 ### Usage
 
-Check out more details in our [documentation](https://github.com/openwallet-foundation-labs/sd-jwt-js/tree/next/docs) or [examples](https://github.com/openwallet-foundation-labs/sd-jwt-js/tree/next/examples)
+Check out more details in our [documentation](https://github.com/openwallet-foundation-labs/sd-jwt-js/tree/main/docs) or [examples](https://github.com/openwallet-foundation-labs/sd-jwt-js/tree/main/examples)
 
 ### Dependencies
 


### PR DESCRIPTION
I changed old links connected to `next` branch to `main` branch
It closes #186 