### PR TITLE
Feat/jwt status list

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -27,7 +27,7 @@ export class SDJwtInstance<ExtendedPayload extends SdJwtPayload> {
 
   public static DEFAULT_hashAlg = 'sha-256';
 
-  private userConfig: SDJWTConfig = {};
+  protected userConfig: SDJWTConfig = {};
 
   constructor(userConfig?: SDJWTConfig) {
     if (userConfig) {

--- a/packages/jwt-status-list/README.md
+++ b/packages/jwt-status-list/README.md
@@ -1,0 +1,73 @@
+![License](https://img.shields.io/github/license/openwallet-foundation-labs/sd-jwt-js.svg)
+![NPM](https://img.shields.io/npm/v/%40sd-jwt%2Fhash)
+![Release](https://img.shields.io/github/v/release/openwallet-foundation-labs/sd-jwt-js)
+![Stars](https://img.shields.io/github/stars/openwallet-foundation-labs/sd-jwt-js)
+
+# JWT Status List
+
+This implementation is based on the this [IETF draft](https://datatracker.ietf.org/doc/draft-ietf-oauth-status-list/)
+
+This status list is an encoded bit string where the status can be represented by multiple bits. This library provides functions to create and read the status list from a JWT and also to verify the status of a specific entry.
+
+
+## Installation
+
+```bash
+npm install jwt-status-list
+```
+
+## Usage
+
+Creation of a JWT Status List:
+```typescript
+// pass the list as an array and the amount of bits per entry.
+const list = new StatusList([1, 0, 1, 1, 1], 1);
+const iss = 'https://example.com';
+const payload: JWTPayload = {
+    iss,
+    sub: `${iss}/statuslist/1`,
+    iat: new Date().getTime() / 1000,
+};
+const header: JWTHeaderParameters = { alg: 'ES256' };
+
+const jwt = createUnsignedJWT(list, payload, header);
+
+// Sign the JWT with the private key
+const signedJwt = await jwt.sign(privateKey);
+
+```
+
+Interaction with a JWT Status List:
+```typescript
+//validation of the JWT is not provided by this library!!!
+
+// jwt that includes the status list reference
+const reference = getStatusListFromJWT(jwt);
+
+// download the status list
+const list = await fetch(reference.uri);
+
+//TODO: validate that the list jwt is signed by the issuer and is not expired!!!
+
+//extract the status list
+const statusList = getListFromStatusListJWT(list);
+
+//get the status of a specific entry
+const status = statusList.getStatus(reference.idx);
+
+// handle the status
+```
+
+## Development
+
+Install the dependencies:
+
+```bash
+pnpm install
+```
+
+Run the tests:
+
+```bash
+pnpm test
+```

--- a/packages/jwt-status-list/README.md
+++ b/packages/jwt-status-list/README.md
@@ -3,19 +3,30 @@
 ![Release](https://img.shields.io/github/v/release/openwallet-foundation-labs/sd-jwt-js)
 ![Stars](https://img.shields.io/github/stars/openwallet-foundation-labs/sd-jwt-js)
 
-# JWT Status List
+# SD-JWT Implementation in JavaScript (TypeScript)
 
-This implementation is based on the this [IETF draft](https://datatracker.ietf.org/doc/draft-ietf-oauth-status-list/)
+## jwt-status-list
+An implementation of the [Token Status List](https://datatracker.ietf.org/doc/draft-ietf-oauth-status-list/) for a JWT representation, not for CBOR.
+This library helps to verify the status of a specific entry in a JWT, and to generate a status list and pack it into a signed JWT. It does not provide any functions to manage the status list itself.
 
-This status list is an encoded bit string where the status can be represented by multiple bits. This library provides functions to create and read the status list from a JWT and also to verify the status of a specific entry.
 
 
 ## Installation
 
+To install this project, run the following command:
+
 ```bash
-npm install jwt-status-list
+# using npm
+npm install @sd-jwt/jwt-status-list
+
+# using yarn
+yarn add @sd-jwt/jwt-status-list
+
+# using pnpm
+pnpm install @sd-jwt/jwt-status-list
 ```
 
+Ensure you have Node.js installed as a prerequisite.
 ## Usage
 
 Creation of a JWT Status List:
@@ -27,6 +38,8 @@ const payload: JWTPayload = {
     iss,
     sub: `${iss}/statuslist/1`,
     iat: new Date().getTime() / 1000,
+    ttl: 3000, // time to live in seconds, optional
+    exp: new Date().getTime() / 1000 + 3600, // optional
 };
 const header: JWTHeaderParameters = { alg: 'ES256' };
 
@@ -57,6 +70,9 @@ const status = statusList.getStatus(reference.idx);
 
 // handle the status
 ```
+
+### Caching the status list
+Depending on the  `ttl` field if provided the status list can be cached for a certain amount of time. This library has no internal cache mechanism, so it is up to the user to implement it for example by providing a custom `fetchStatusList` function.
 
 ## Development
 

--- a/packages/jwt-status-list/README.md
+++ b/packages/jwt-status-list/README.md
@@ -43,14 +43,16 @@ const payload: JWTPayload = {
 };
 const header: JWTHeaderParameters = { alg: 'ES256' };
 
-const jwt = createUnsignedJWT(list, payload, header);
+const jwt = createHeaderAndPayload(list, payload, header);
 
-// Sign the JWT with the private key
-const signedJwt = await jwt.sign(privateKey);
+// Sign the JWT with the private key, e.g. using the `jose` library
+const jwt = await new SignJWT(values.payload)
+      .setProtectedHeader(values.header)
+      .sign(privateKey);
 
 ```
 
-Interaction with a JWT Status List:
+Interaction with a JWT status list on low level:
 ```typescript
 //validation of the JWT is not provided by this library!!!
 
@@ -67,9 +69,12 @@ const statusList = getListFromStatusListJWT(list);
 
 //get the status of a specific entry
 const status = statusList.getStatus(reference.idx);
-
-// handle the status
 ```
+
+### Integration into sd-jwt-vc
+The status list can be integrated into the [sd-jwt-vc](../sd-jwt-vc/README.md) library to provide a way to verify the status of a credential. In the [test folder](../sd-jwt-vc/src/test/index.spec.ts) you will find an example how to add the status reference to a credential and also how to verify the status of a credential.
+
+```typescript
 
 ### Caching the status list
 Depending on the  `ttl` field if provided the status list can be cached for a certain amount of time. This library has no internal cache mechanism, so it is up to the user to implement it for example by providing a custom `fetchStatusList` function.

--- a/packages/jwt-status-list/package.json
+++ b/packages/jwt-status-list/package.json
@@ -19,7 +19,11 @@
     "test:browser": "vitest run ./src/test/*.spec.ts --environment jsdom",
     "test:cov": "vitest run --coverage"
   },
-  "keywords": ["sd-jwt-vc", "status-list", "sd-jwt"],
+  "keywords": [
+    "sd-jwt-vc",
+    "status-list",
+    "sd-jwt"
+  ],
   "engines": {
     "node": ">=18"
   },
@@ -38,6 +42,7 @@
     "jose": "^5.2.2"
   },
   "dependencies": {
+    "@sd-jwt/types": "workspace:*",
     "base64url": "^3.0.1",
     "pako": "^2.1.0"
   },
@@ -45,12 +50,17 @@
     "access": "public"
   },
   "tsup": {
-    "entry": ["./src/index.ts"],
+    "entry": [
+      "./src/index.ts"
+    ],
     "sourceMap": true,
     "splitting": false,
     "clean": true,
     "dts": true,
-    "format": ["cjs", "esm"]
+    "format": [
+      "cjs",
+      "esm"
+    ]
   },
   "gitHead": "ded40e4551bde7ae93083181bf26bd1b38bbfcfb"
 }

--- a/packages/jwt-status-list/package.json
+++ b/packages/jwt-status-list/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "@sd-jwt/sd-jwt-vc",
+  "name": "@sd-jwt/jwt-status-list",
   "version": "0.6.1",
-  "description": "sd-jwt draft 7 implementation in typescript",
+  "description": "Implementation based on https://datatracker.ietf.org/doc/draft-ietf-oauth-status-list/",
   "main": "dist/index.js",
   "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
@@ -14,16 +14,15 @@
   "scripts": {
     "build": "rm -rf **/dist && tsup",
     "lint": "biome lint ./src",
-    "test": "pnpm run test:node && pnpm run test:browser && pnpm run test:e2e && pnpm run test:cov",
-    "test:node": "vitest run ./src/test/*.spec.ts && vitest run ./src/test/*.spec.ts --environment jsdom",
+    "test": "pnpm run test:node && pnpm run test:browser && pnpm run test:cov",
+    "test:node": "vitest run ./src/test/*.spec.ts",
     "test:browser": "vitest run ./src/test/*.spec.ts --environment jsdom",
-    "test:e2e": "vitest run ./test/*e2e.spec.ts --environment node",
     "test:cov": "vitest run --coverage"
   },
   "keywords": [
-    "sd-jwt",
-    "sdjwt",
-    "sd-jwt-vc"
+    "sd-jwt-vc",
+    "status-list",
+    "sd-jwt"
   ],
   "engines": {
     "node": ">=18"
@@ -32,20 +31,19 @@
     "type": "git",
     "url": "https://github.com/openwallet-foundation-labs/sd-jwt-js"
   },
-  "author": "Lukas.J.Han <lukas.j.han@gmail.com>",
+  "author": "Mirko Mollik <mirkomollik@gmail.com>",
   "homepage": "https://github.com/openwallet-foundation-labs/sd-jwt-js/wiki",
   "bugs": {
     "url": "https://github.com/openwallet-foundation-labs/sd-jwt-js/issues"
   },
   "license": "Apache-2.0",
-  "dependencies": {
-    "@sd-jwt/core": "workspace:*",
-    "@sd-jwt/jwt-status-list": "workspace:*"
-  },
   "devDependencies": {
-    "@sd-jwt/crypto-nodejs": "workspace:*",
-    "@sd-jwt/types": "workspace:*",
+    "@types/pako": "^2.0.3",
     "jose": "^5.2.2"
+  },
+  "dependencies": {
+    "base64url": "^3.0.1",
+    "pako": "^2.1.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/jwt-status-list/package.json
+++ b/packages/jwt-status-list/package.json
@@ -19,11 +19,7 @@
     "test:browser": "vitest run ./src/test/*.spec.ts --environment jsdom",
     "test:cov": "vitest run --coverage"
   },
-  "keywords": [
-    "sd-jwt-vc",
-    "status-list",
-    "sd-jwt"
-  ],
+  "keywords": ["sd-jwt-vc", "status-list", "sd-jwt"],
   "engines": {
     "node": ">=18"
   },
@@ -49,17 +45,12 @@
     "access": "public"
   },
   "tsup": {
-    "entry": [
-      "./src/index.ts"
-    ],
+    "entry": ["./src/index.ts"],
     "sourceMap": true,
     "splitting": false,
     "clean": true,
     "dts": true,
-    "format": [
-      "cjs",
-      "esm"
-    ]
+    "format": ["cjs", "esm"]
   },
   "gitHead": "ded40e4551bde7ae93083181bf26bd1b38bbfcfb"
 }

--- a/packages/jwt-status-list/package.json
+++ b/packages/jwt-status-list/package.json
@@ -19,11 +19,7 @@
     "test:browser": "vitest run ./src/test/*.spec.ts --environment jsdom",
     "test:cov": "vitest run --coverage"
   },
-  "keywords": [
-    "sd-jwt-vc",
-    "status-list",
-    "sd-jwt"
-  ],
+  "keywords": ["sd-jwt-vc", "status-list", "sd-jwt"],
   "engines": {
     "node": ">=18"
   },
@@ -50,17 +46,12 @@
     "access": "public"
   },
   "tsup": {
-    "entry": [
-      "./src/index.ts"
-    ],
+    "entry": ["./src/index.ts"],
     "sourceMap": true,
     "splitting": false,
     "clean": true,
     "dts": true,
-    "format": [
-      "cjs",
-      "esm"
-    ]
+    "format": ["cjs", "esm"]
   },
   "gitHead": "ded40e4551bde7ae93083181bf26bd1b38bbfcfb"
 }

--- a/packages/jwt-status-list/src/index.ts
+++ b/packages/jwt-status-list/src/index.ts
@@ -1,0 +1,3 @@
+export * from './status-list.js';
+export * from './status-list-jwt.js';
+export * from './types.js';

--- a/packages/jwt-status-list/src/status-list-jwt.ts
+++ b/packages/jwt-status-list/src/status-list-jwt.ts
@@ -1,0 +1,73 @@
+import { StatusList } from './status-list.js';
+import type {
+  JWTPayload,
+  JWTHeaderParameters,
+  JWTwithStatusListPayload,
+  StatusListEntry,
+  StatusListJWTPayload,
+} from './types.js';
+import base64Url from 'base64url';
+
+/**
+ * Decode a JWT and return the payload.
+ * @param jwt JWT token in compact JWS serialization.
+ * @returns Payload of the JWT.
+ */
+function decodeJwt<T>(jwt: string): T {
+  const parts = jwt.split('.');
+  return JSON.parse(base64Url.decode(parts[1]));
+}
+
+/**
+ * Adds the status list to the payload and header of a JWT.
+ * @param list
+ * @param payload
+ * @param header
+ * @returns The header and payload with the status list added.
+ */
+export function createHeaderAndPayload(
+  list: StatusList,
+  payload: JWTPayload,
+  header: JWTHeaderParameters,
+) {
+  // validate if the required fieds are present based on https://www.ietf.org/archive/id/draft-ietf-oauth-status-list-02.html#section-5.1
+
+  if (!payload.iss) {
+    throw new Error('iss field is required');
+  }
+  if (!payload.sub) {
+    throw new Error('sub field is required');
+  }
+  if (!payload.iat) {
+    throw new Error('iat field is required');
+  }
+  //exp and tll are optional. We will not validate the business logic of the values like exp > iat etc.
+
+  header.typ = 'statuslist+jwt';
+  payload.status_list = {
+    bits: list.getBitsPerStatus(),
+    lst: list.compressStatusList(),
+  };
+  return { header, payload };
+}
+
+/**
+ * Get the status list from a JWT, but do not verify the signature.
+ * @param jwt
+ * @returns
+ */
+export function getListFromStatusListJWT(jwt: string): StatusList {
+  const payload = decodeJwt<StatusListJWTPayload>(jwt);
+  const statusList = payload.status_list;
+  return StatusList.decompressStatusList(statusList.lst, statusList.bits);
+}
+
+/**
+ * Get the status list entry from a JWT, but do not verify the signature.
+ * @param jwt
+ * @returns
+ */
+export function getStatusListFromJWT(jwt: string): StatusListEntry {
+  const payload = decodeJwt<JWTwithStatusListPayload>(jwt);
+  return payload.status.status_list;
+}

--- a/packages/jwt-status-list/src/status-list-jwt.ts
+++ b/packages/jwt-status-list/src/status-list-jwt.ts
@@ -1,8 +1,8 @@
+import type { JwtPayload } from '@sd-jwt/types';
 import { StatusList } from './status-list.js';
 import type {
-  JWTPayload,
-  JWTHeaderParameters,
   JWTwithStatusListPayload,
+  JwtHeaderParameters,
   StatusListEntry,
   StatusListJWTPayload,
 } from './types.js';
@@ -27,8 +27,8 @@ function decodeJwt<T>(jwt: string): T {
  */
 export function createHeaderAndPayload(
   list: StatusList,
-  payload: JWTPayload,
-  header: JWTHeaderParameters,
+  payload: JwtPayload,
+  header: JwtHeaderParameters,
 ) {
   // validate if the required fieds are present based on https://www.ietf.org/archive/id/draft-ietf-oauth-status-list-02.html#section-5.1
 

--- a/packages/jwt-status-list/src/status-list-jwt.ts
+++ b/packages/jwt-status-list/src/status-list-jwt.ts
@@ -2,7 +2,7 @@ import type { JwtPayload } from '@sd-jwt/types';
 import { StatusList } from './status-list.js';
 import type {
   JWTwithStatusListPayload,
-  JwtHeaderParameters,
+  StatusListJWTHeaderParameters,
   StatusListEntry,
   StatusListJWTPayload,
 } from './types.js';
@@ -28,7 +28,7 @@ function decodeJwt<T>(jwt: string): T {
 export function createHeaderAndPayload(
   list: StatusList,
   payload: JwtPayload,
-  header: JwtHeaderParameters,
+  header: StatusListJWTHeaderParameters,
 ) {
   // validate if the required fieds are present based on https://www.ietf.org/archive/id/draft-ietf-oauth-status-list-02.html#section-5.1
 

--- a/packages/jwt-status-list/src/status-list.ts
+++ b/packages/jwt-status-list/src/status-list.ts
@@ -1,0 +1,167 @@
+import { deflate, inflate } from 'pako';
+import base64Url from 'base64url';
+import type { BitsPerStatus } from './types.js';
+/**
+ * StatusListManager is a class that manages a list of statuses with variable bit size.
+ */
+export class StatusList {
+  private statusList: number[];
+  private bitsPerStatus: BitsPerStatus;
+  private totalStatuses: number;
+
+  /**
+   * Create a new StatusListManager instance.
+   * @param statusList
+   * @param bitsPerStatus
+   */
+  constructor(statusList: number[], bitsPerStatus: BitsPerStatus) {
+    if (![1, 2, 4, 8].includes(bitsPerStatus)) {
+      throw new Error('bitsPerStatus must be 1, 2, 4, or 8');
+    }
+    //check that the entries in the statusList are within the range of the bitsPerStatus
+    for (let i = 0; i < statusList.length; i++) {
+      if (statusList[i] > 2 ** bitsPerStatus) {
+        throw Error(
+          `Status value out of range at index ${i} with value ${statusList[i]}`,
+        );
+      }
+    }
+    this.statusList = statusList;
+    this.bitsPerStatus = bitsPerStatus;
+    this.totalStatuses = statusList.length;
+  }
+
+  /**
+   * Get the number of statuses.
+   * @returns
+   */
+  getBitsPerStatus(): BitsPerStatus {
+    return this.bitsPerStatus;
+  }
+
+  /**
+   * Get the status at a specific index.
+   * @param index
+   * @returns
+   */
+  getStatus(index: number): number {
+    if (index < 0 || index >= this.totalStatuses) {
+      throw new Error('Index out of bounds');
+    }
+    return this.statusList[index];
+  }
+
+  /**
+   * Set the status at a specific index.
+   * @param index
+   * @param value
+   */
+  setStatus(index: number, value: number): void {
+    if (index < 0 || index >= this.totalStatuses) {
+      throw new Error('Index out of bounds');
+    }
+    this.statusList[index] = value;
+  }
+
+  /**
+   * Compress the status list.
+   * @returns
+   */
+  compressStatusList(): string {
+    const byteArray = this.encodeStatusList();
+    const compressed = deflate(byteArray, { level: 9 });
+    return base64Url.encode(compressed as Buffer);
+  }
+
+  /**
+   * Decompress the compressed status list and return a new StatusList instance.
+   * @param compressed
+   * @param bitsPerStatus
+   * @returns
+   */
+  static decompressStatusList(
+    compressed: string,
+    bitsPerStatus: BitsPerStatus,
+  ): StatusList {
+    const decoded = new Uint8Array(
+      base64Url
+        .decode(compressed, 'binary')
+        .split('')
+        .map((c) => c.charCodeAt(0)),
+    );
+    try {
+      const decompressed = inflate(decoded);
+      const statusList = StatusList.decodeStatusList(
+        decompressed,
+        bitsPerStatus,
+      );
+      return new StatusList(statusList, bitsPerStatus);
+    } catch (err: unknown) {
+      throw new Error(`Decompression failed: ${err}`);
+    }
+  }
+
+  /**
+   * Encode the status list into a byte array.
+   * @returns
+   **/
+  public encodeStatusList(): Uint8Array {
+    const numBits = this.bitsPerStatus;
+    const numBytes = Math.ceil((this.totalStatuses * numBits) / 8);
+    const byteArray = new Uint8Array(numBytes);
+    let byteIndex = 0;
+    let bitIndex = 0;
+    let currentByte = '';
+    for (let i = 0; i < this.totalStatuses; i++) {
+      const status = this.statusList[i];
+      // Place bits from status into currentByte, starting from the most significant bit.
+      currentByte = status.toString(2).padStart(numBits, '0') + currentByte;
+      bitIndex += numBits;
+
+      // If currentByte is full or this is the last status, add it to byteArray and reset currentByte and bitIndex.
+      if (bitIndex >= 8 || i === this.totalStatuses - 1) {
+        // If this is the last status and bitIndex is not a multiple of 8, shift currentByte to the left.
+        if (i === this.totalStatuses - 1 && bitIndex % 8 !== 0) {
+          currentByte = currentByte.padStart(8, '0');
+        }
+        byteArray[byteIndex] = Number.parseInt(currentByte, 2);
+        currentByte = '';
+        bitIndex = 0;
+        byteIndex++;
+      }
+    }
+
+    return byteArray;
+  }
+
+  /**
+   * Decode the byte array into a status list.
+   * @param byteArray
+   * @param bitsPerStatus
+   * @returns
+   */
+  private static decodeStatusList(
+    byteArray: Uint8Array,
+    bitsPerStatus: BitsPerStatus,
+  ): number[] {
+    const numBits = bitsPerStatus;
+    const totalStatuses = (byteArray.length * 8) / numBits;
+    const statusList = new Array<number>(totalStatuses);
+    let bitIndex = 0; // Current position in byte
+    for (let i = 0; i < totalStatuses; i++) {
+      const byte = byteArray[Math.floor((i * numBits) / 8)];
+      let byteString = byte.toString(2);
+      if (byteString.length < 8) {
+        byteString = '0'.repeat(8 - byteString.length) + byteString;
+      }
+      const status = byteString.slice(bitIndex, bitIndex + numBits);
+      const group = Math.floor(i / (8 / numBits));
+      const indexInGroup = i % (8 / numBits);
+      const position =
+        group * (8 / numBits) + (8 / numBits + -1 - indexInGroup);
+      statusList[position] = Number.parseInt(status, 2);
+      bitIndex = (bitIndex + numBits) % 8;
+    }
+    return statusList;
+  }
+}

--- a/packages/jwt-status-list/src/test/status-list-jwt.spec.ts
+++ b/packages/jwt-status-list/src/test/status-list-jwt.spec.ts
@@ -1,0 +1,124 @@
+import {
+  createHeaderAndPayload,
+  getListFromStatusListJWT,
+  getStatusListFromJWT,
+} from '../status-list-jwt';
+import type {
+  JWTHeaderParameters,
+  JWTPayload,
+  JWTwithStatusListPayload,
+} from '../types';
+import { StatusList } from '../status-list';
+import { jwtVerify, KeyLike, SignJWT } from 'jose';
+import { beforeAll, describe, expect, it } from 'vitest';
+import { generateKeyPairSync } from 'node:crypto';
+
+describe('JWTStatusList', () => {
+  let publicKey: KeyLike;
+  let privateKey: KeyLike;
+
+  beforeAll(() => {
+    // Generate a key pair for testing
+    const keyPair = generateKeyPairSync('ec', {
+      namedCurve: 'P-256',
+    });
+    publicKey = keyPair.publicKey;
+    privateKey = keyPair.privateKey;
+  });
+
+  it('should create a JWT with a status list', async () => {
+    const statusList = new StatusList([1, 0, 1, 1, 1], 1);
+    const iss = 'https://example.com';
+    const payload: JWTPayload = {
+      iss,
+      sub: `${iss}/statuslist/1`,
+      iat: new Date().getTime() / 1000,
+    };
+    const header: JWTHeaderParameters = { alg: 'ES256' };
+
+    const values = createHeaderAndPayload(statusList, payload, header);
+
+    const jwt = await new SignJWT(values.payload)
+      .setProtectedHeader(values.header)
+      .sign(privateKey);
+    // Verify the signed JWT with the public key
+    const verified = await jwtVerify(jwt, publicKey);
+    expect(verified.payload.status_list).toEqual({
+      bits: statusList.getBitsPerStatus(),
+      lst: statusList.compressStatusList(),
+    });
+    expect(verified.protectedHeader.typ).toBe('statuslist+jwt');
+  });
+
+  it('should get the status list from a JWT without verifying the signature', async () => {
+    const list = [1, 0, 1, 0, 1];
+    const statusList = new StatusList(list, 1);
+    const iss = 'https://example.com';
+    const payload: JWTPayload = {
+      iss,
+      sub: `${iss}/statuslist/1`,
+      iat: new Date().getTime() / 1000,
+    };
+    const header: JWTHeaderParameters = { alg: 'ES256' };
+
+    const values = createHeaderAndPayload(statusList, payload, header);
+
+    const jwt = await new SignJWT(values.payload)
+      .setProtectedHeader(values.header)
+      .sign(privateKey);
+
+    const extractedList = getListFromStatusListJWT(jwt);
+    for (let i = 0; i < list.length; i++) {
+      expect(extractedList.getStatus(i)).toBe(list[i]);
+    }
+  });
+
+  it('should throw an error if the JWT is invalid', async () => {
+    const list = [1, 0, 1, 0, 1];
+    const statusList = new StatusList(list, 2);
+    const iss = 'https://example.com';
+    const header: JWTHeaderParameters = { alg: 'ES256' };
+    let payload: any = {
+      sub: `${iss}/statuslist/1`,
+      iat: new Date().getTime() / 1000,
+    };
+    expect(() => {
+      createHeaderAndPayload(statusList, payload as JWTPayload, header);
+    }).toThrow('iss field is required');
+
+    payload = {
+      iss,
+      iat: new Date().getTime() / 1000,
+    };
+    expect(() => createHeaderAndPayload(statusList, payload, header)).toThrow(
+      'sub field is required',
+    );
+
+    payload = {
+      iss,
+      sub: `${iss}/statuslist/1`,
+    };
+    expect(() => createHeaderAndPayload(statusList, payload, header)).toThrow(
+      'iat field is required',
+    );
+  });
+
+  it('should get the status entry from a JWT', async () => {
+    const payload: JWTwithStatusListPayload = {
+      iss: 'https://example.com',
+      sub: 'https://example.com/status/1',
+      iat: new Date().getTime() / 1000,
+      status: {
+        status_list: {
+          idx: 0,
+          uri: 'https://example.com/status/1',
+        },
+      },
+    };
+    const jwt = await new SignJWT(payload)
+      .setProtectedHeader({ alg: 'ES256' })
+      .sign(privateKey);
+    const reference = getStatusListFromJWT(jwt);
+    expect(reference).toEqual(payload.status.status_list);
+  });
+});

--- a/packages/jwt-status-list/src/test/status-list-jwt.spec.ts
+++ b/packages/jwt-status-list/src/test/status-list-jwt.spec.ts
@@ -3,7 +3,10 @@ import {
   getListFromStatusListJWT,
   getStatusListFromJWT,
 } from '../status-list-jwt';
-import type { JwtHeaderParameters, JWTwithStatusListPayload } from '../types';
+import type {
+  StatusListJWTHeaderParameters,
+  JWTwithStatusListPayload,
+} from '../types';
 import { StatusList } from '../status-list';
 import { jwtVerify, type KeyLike, SignJWT } from 'jose';
 import { beforeAll, describe, expect, it } from 'vitest';
@@ -13,6 +16,11 @@ import type { JwtPayload } from '@sd-jwt/types';
 describe('JWTStatusList', () => {
   let publicKey: KeyLike;
   let privateKey: KeyLike;
+
+  const header: StatusListJWTHeaderParameters = {
+    alg: 'ES256',
+    typ: 'statuslist+jwt',
+  };
 
   beforeAll(() => {
     // Generate a key pair for testing
@@ -31,7 +39,6 @@ describe('JWTStatusList', () => {
       sub: `${iss}/statuslist/1`,
       iat: new Date().getTime() / 1000,
     };
-    const header: JwtHeaderParameters = { alg: 'ES256' };
 
     const values = createHeaderAndPayload(statusList, payload, header);
 
@@ -56,7 +63,6 @@ describe('JWTStatusList', () => {
       sub: `${iss}/statuslist/1`,
       iat: new Date().getTime() / 1000,
     };
-    const header: JwtHeaderParameters = { alg: 'ES256' };
 
     const values = createHeaderAndPayload(statusList, payload, header);
 
@@ -74,7 +80,6 @@ describe('JWTStatusList', () => {
     const list = [1, 0, 1, 0, 1];
     const statusList = new StatusList(list, 2);
     const iss = 'https://example.com';
-    const header: JwtHeaderParameters = { alg: 'ES256' };
     let payload: JwtPayload = {
       sub: `${iss}/statuslist/1`,
       iat: new Date().getTime() / 1000,

--- a/packages/jwt-status-list/src/test/status-list-jwt.spec.ts
+++ b/packages/jwt-status-list/src/test/status-list-jwt.spec.ts
@@ -3,15 +3,12 @@ import {
   getListFromStatusListJWT,
   getStatusListFromJWT,
 } from '../status-list-jwt';
-import type {
-  JWTHeaderParameters,
-  JWTPayload,
-  JWTwithStatusListPayload,
-} from '../types';
+import type { JwtHeaderParameters, JWTwithStatusListPayload } from '../types';
 import { StatusList } from '../status-list';
-import { jwtVerify, KeyLike, SignJWT } from 'jose';
+import { jwtVerify, type KeyLike, SignJWT } from 'jose';
 import { beforeAll, describe, expect, it } from 'vitest';
 import { generateKeyPairSync } from 'node:crypto';
+import type { JwtPayload } from '@sd-jwt/types';
 
 describe('JWTStatusList', () => {
   let publicKey: KeyLike;
@@ -29,12 +26,12 @@ describe('JWTStatusList', () => {
   it('should create a JWT with a status list', async () => {
     const statusList = new StatusList([1, 0, 1, 1, 1], 1);
     const iss = 'https://example.com';
-    const payload: JWTPayload = {
+    const payload: JwtPayload = {
       iss,
       sub: `${iss}/statuslist/1`,
       iat: new Date().getTime() / 1000,
     };
-    const header: JWTHeaderParameters = { alg: 'ES256' };
+    const header: JwtHeaderParameters = { alg: 'ES256' };
 
     const values = createHeaderAndPayload(statusList, payload, header);
 
@@ -54,12 +51,12 @@ describe('JWTStatusList', () => {
     const list = [1, 0, 1, 0, 1];
     const statusList = new StatusList(list, 1);
     const iss = 'https://example.com';
-    const payload: JWTPayload = {
+    const payload: JwtPayload = {
       iss,
       sub: `${iss}/statuslist/1`,
       iat: new Date().getTime() / 1000,
     };
-    const header: JWTHeaderParameters = { alg: 'ES256' };
+    const header: JwtHeaderParameters = { alg: 'ES256' };
 
     const values = createHeaderAndPayload(statusList, payload, header);
 
@@ -77,13 +74,13 @@ describe('JWTStatusList', () => {
     const list = [1, 0, 1, 0, 1];
     const statusList = new StatusList(list, 2);
     const iss = 'https://example.com';
-    const header: JWTHeaderParameters = { alg: 'ES256' };
-    let payload: any = {
+    const header: JwtHeaderParameters = { alg: 'ES256' };
+    let payload: JwtPayload = {
       sub: `${iss}/statuslist/1`,
       iat: new Date().getTime() / 1000,
     };
     expect(() => {
-      createHeaderAndPayload(statusList, payload as JWTPayload, header);
+      createHeaderAndPayload(statusList, payload as JwtPayload, header);
     }).toThrow('iss field is required');
 
     payload = {

--- a/packages/jwt-status-list/src/test/status-list.spec.ts
+++ b/packages/jwt-status-list/src/test/status-list.spec.ts
@@ -1,0 +1,222 @@
+import { describe, expect, it, test } from 'vitest';
+import { StatusList } from '../index';
+import type { BitsPerStatus } from '../types';
+
+describe('StatusList', () => {
+  const listLength = 10000;
+
+  it('test from the example with 1 bit status', () => {
+    const status: number[] = [];
+    status[0] = 1;
+    status[1] = 0;
+    status[2] = 0;
+    status[3] = 1;
+    status[4] = 1;
+    status[5] = 1;
+    status[6] = 0;
+    status[7] = 1;
+    status[8] = 1;
+    status[9] = 1;
+    status[10] = 0;
+    status[11] = 0;
+    status[12] = 0;
+    status[13] = 1;
+    status[14] = 0;
+    status[15] = 1;
+    const manager = new StatusList(status, 1);
+    const encoded = manager.compressStatusList();
+    expect(encoded).toBe('eNrbuRgAAhcBXQ');
+    const l = StatusList.decompressStatusList(encoded, 1);
+    for (let i = 0; i < status.length; i++) {
+      expect(l.getStatus(i)).toBe(status[i]);
+    }
+  });
+
+  it('test from the example with 2 bit status', () => {
+    const status: number[] = [];
+    status[0] = 1;
+    status[1] = 2;
+    status[2] = 0;
+    status[3] = 3;
+    status[4] = 0;
+    status[5] = 1;
+    status[6] = 0;
+    status[7] = 1;
+    status[8] = 1;
+    status[9] = 2;
+    status[10] = 3;
+    status[11] = 3;
+    const manager = new StatusList(status, 2);
+    const encoded = manager.compressStatusList();
+    expect(encoded).toBe('eNo76fITAAPfAgc');
+    const l = StatusList.decompressStatusList(encoded, 2);
+    for (let i = 0; i < status.length; i++) {
+      expect(l.getStatus(i)).toBe(status[i]);
+    }
+  });
+
+  // Test with different bitsPerStatus values
+  describe.each([
+    [1 as BitsPerStatus],
+    [2 as BitsPerStatus],
+    [4 as BitsPerStatus],
+    [8 as BitsPerStatus],
+  ])('with %i bitsPerStatus', (bitsPerStatus) => {
+    let manager: StatusList;
+
+    function createListe(
+      length: number,
+      bitsPerStatus: BitsPerStatus,
+    ): number[] {
+      const list: number[] = [];
+      for (let i = 0; i < length; i++) {
+        list.push(Math.floor(Math.random() * 2 ** bitsPerStatus));
+      }
+      return list;
+    }
+
+    it('should pass an incorrect list with wrong entries', () => {
+      expect(() => {
+        new StatusList([2 ** bitsPerStatus + 1], bitsPerStatus);
+      }).toThrowError();
+    });
+
+    it('should compress and decompress status list correctly', () => {
+      const statusList = createListe(listLength, bitsPerStatus);
+      manager = new StatusList(statusList, bitsPerStatus);
+      const compressedStatusList = manager.compressStatusList();
+      const decodedStatuslist = StatusList.decompressStatusList(
+        compressedStatusList,
+        bitsPerStatus,
+      );
+      checkIfEqual(decodedStatuslist, statusList);
+    });
+
+    it('should return the bitsPerStatus value', () => {
+      const statusList = createListe(
+        listLength,
+        bitsPerStatus as BitsPerStatus,
+      );
+      manager = new StatusList(statusList, bitsPerStatus as BitsPerStatus);
+      expect(manager.getBitsPerStatus()).toBe(bitsPerStatus);
+    });
+
+    it('getStatus returns the correct status', () => {
+      const statusList = createListe(
+        listLength,
+        bitsPerStatus as BitsPerStatus,
+      );
+      manager = new StatusList(statusList, bitsPerStatus as BitsPerStatus);
+
+      for (let i = 0; i < statusList.length; i++) {
+        expect(manager.getStatus(i)).toBe(statusList[i]);
+      }
+    });
+
+    it('setStatus sets the correct status', () => {
+      const statusList = createListe(
+        listLength,
+        bitsPerStatus as BitsPerStatus,
+      );
+      manager = new StatusList(statusList, bitsPerStatus as BitsPerStatus);
+
+      const newValue = Math.floor(Math.random() * 2 ** bitsPerStatus);
+      manager.setStatus(0, newValue);
+      expect(manager.getStatus(0)).toBe(newValue);
+    });
+
+    it('getStatus throws an error for out of bounds index', () => {
+      const statusList = createListe(
+        listLength,
+        bitsPerStatus as BitsPerStatus,
+      );
+      manager = new StatusList(statusList, bitsPerStatus as BitsPerStatus);
+
+      expect(() => manager.getStatus(-1)).toThrow('Index out of bounds');
+      expect(() => manager.getStatus(listLength)).toThrow(
+        'Index out of bounds',
+      );
+    });
+
+    it('setStatus throws an error for out of bounds index', () => {
+      const statusList = createListe(
+        listLength,
+        bitsPerStatus as BitsPerStatus,
+      );
+      manager = new StatusList(statusList, bitsPerStatus as BitsPerStatus);
+
+      expect(() => manager.setStatus(-1, 5)).toThrow('Index out of bounds');
+      expect(() => manager.setStatus(listLength, 6)).toThrow(
+        'Index out of bounds',
+      );
+    });
+
+    it('decompressStatusList throws an error when decompression fails', () => {
+      const statusList = createListe(
+        listLength,
+        bitsPerStatus as BitsPerStatus,
+      );
+      manager = new StatusList(statusList, bitsPerStatus as BitsPerStatus);
+
+      const invalidCompressedData = 'invalid data';
+
+      expect(() =>
+        StatusList.decompressStatusList(invalidCompressedData, bitsPerStatus),
+      ).toThrowError();
+    });
+
+    test('encodeStatusList covers remaining bits in last byte', () => {
+      const bitsPerStatus = 1;
+      const totalStatuses = 10; // Not a multiple of 8
+      const statusList = Array(totalStatuses).fill(0);
+      const manager = new StatusList(statusList, bitsPerStatus);
+      const encoded = manager.compressStatusList();
+      const decoded = StatusList.decompressStatusList(encoded, bitsPerStatus);
+      //technially we need to validate all the status but we are just checking the length
+      checkIfEqual(decoded, statusList);
+    });
+
+    /**
+     * Check if the status list is equal to the given list.
+     * @param statuslist1
+     * @param rawStatusList
+     */
+    function checkIfEqual(statuslist1: StatusList, rawStatusList: number[]) {
+      for (let i = 0; i < rawStatusList.length; i++) {
+        expect(statuslist1.getStatus(i)).toBe(rawStatusList[i]);
+      }
+    }
+
+    describe('constructor', () => {
+      test.each<[number]>([
+        [3], // Invalid bitsPerStatus value
+        [5], // Invalid bitsPerStatus value
+        [6], // Invalid bitsPerStatus value
+        [7], // Invalid bitsPerStatus value
+        [9], // Invalid bitsPerStatus value
+        [10], // Invalid bitsPerStatus value
+      ])(
+        'throws an error for invalid bitsPerStatus value (%i)',
+        (bitsPerStatus) => {
+          expect(() => {
+            new StatusList([], bitsPerStatus as BitsPerStatus);
+          }).toThrowError('bitsPerStatus must be 1, 2, 4, or 8');
+        },
+      );
+
+      test.each<[BitsPerStatus]>([
+        [1], // Valid bitsPerStatus value
+        [2], // Valid bitsPerStatus value
+        [4], // Valid bitsPerStatus value
+        [8], // Valid bitsPerStatus value
+      ])(
+        'does not throw an error for valid bitsPerStatus value (%i)',
+        (bitsPerStatus) => {
+          expect(() => {
+            new StatusList([], bitsPerStatus);
+          }).not.toThrowError();
+        },
+      );
+    });
+  });
+});

--- a/packages/jwt-status-list/src/types.ts
+++ b/packages/jwt-status-list/src/types.ts
@@ -36,7 +36,8 @@ export type BitsPerStatus = 1 | 2 | 4 | 8;
 /**
  * Header parameters for a JWT.
  */
-export type JwtHeaderParameters = {
+export type StatusListJWTHeaderParameters = {
   alg: string;
+  typ: 'statuslist+jwt';
   [key: string]: unknown;
 };

--- a/packages/jwt-status-list/src/types.ts
+++ b/packages/jwt-status-list/src/types.ts
@@ -1,0 +1,51 @@
+/**
+ * Reference to a status list entry.
+ */
+export interface StatusListEntry {
+  idx: number;
+  uri: string;
+}
+
+/**
+ * Payload for a JWT
+ */
+export interface JWTwithStatusListPayload extends JWTPayload {
+  status: {
+    status_list: StatusListEntry;
+  };
+}
+
+/**
+ * Payload for a JWT with a status list.
+ */
+export interface StatusListJWTPayload extends JWTPayload {
+  status_list: {
+    bits: BitsPerStatus;
+    lst: string;
+  };
+}
+
+/**
+ * BitsPerStatus type.
+ */
+export type BitsPerStatus = 1 | 2 | 4 | 8;
+
+/**
+ * Payload for a JWT.
+ */
+export type JWTPayload = {
+  iss: string;
+  sub: string;
+  iat: number;
+  exp?: number;
+  ttl?: number;
+  [key: string]: unknown;
+};
+
+/**
+ * Header parameters for a JWT.
+ */
+export type JWTHeaderParameters = {
+  alg: string;
+  [key: string]: unknown;
+};

--- a/packages/jwt-status-list/src/types.ts
+++ b/packages/jwt-status-list/src/types.ts
@@ -1,3 +1,5 @@
+import type { JwtPayload } from '@sd-jwt/types';
+
 /**
  * Reference to a status list entry.
  */
@@ -9,7 +11,7 @@ export interface StatusListEntry {
 /**
  * Payload for a JWT
  */
-export interface JWTwithStatusListPayload extends JWTPayload {
+export interface JWTwithStatusListPayload extends JwtPayload {
   status: {
     status_list: StatusListEntry;
   };
@@ -18,7 +20,8 @@ export interface JWTwithStatusListPayload extends JWTPayload {
 /**
  * Payload for a JWT with a status list.
  */
-export interface StatusListJWTPayload extends JWTPayload {
+export interface StatusListJWTPayload extends JwtPayload {
+  ttl?: number;
   status_list: {
     bits: BitsPerStatus;
     lst: string;
@@ -31,21 +34,9 @@ export interface StatusListJWTPayload extends JWTPayload {
 export type BitsPerStatus = 1 | 2 | 4 | 8;
 
 /**
- * Payload for a JWT.
- */
-export type JWTPayload = {
-  iss: string;
-  sub: string;
-  iat: number;
-  exp?: number;
-  ttl?: number;
-  [key: string]: unknown;
-};
-
-/**
  * Header parameters for a JWT.
  */
-export type JWTHeaderParameters = {
+export type JwtHeaderParameters = {
   alg: string;
   [key: string]: unknown;
 };

--- a/packages/jwt-status-list/tsconfig.json
+++ b/packages/jwt-status-list/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist"
+  }
+}

--- a/packages/jwt-status-list/vitest.config.mts
+++ b/packages/jwt-status-list/vitest.config.mts
@@ -1,0 +1,4 @@
+// vite.config.ts
+import { allEnvs } from '../../vitest.shared';
+
+export default allEnvs;

--- a/packages/sd-jwt-vc/README.md
+++ b/packages/sd-jwt-vc/README.md
@@ -83,8 +83,13 @@ const verified = await sdjwt.verify(presentation);
 
 Check out more details in our [documentation](https://github.com/openwallet-foundation-labs/sd-jwt-js/tree/main/docs) or [examples](https://github.com/openwallet-foundation-labs/sd-jwt-js/tree/main/examples)
 
+### Revocation
+To add revocation capabilities, you can use the `@sd-jwt/jwt-status-list` library to create a JWT Status List and include it in the SD-JWT-VC.
+
+
 ### Dependencies
 
 - @sd-jwt/core
 - @sd-jwt/types
 - @sd-jwt/utils
+- @sd-jwt/jwt-status-list

--- a/packages/sd-jwt-vc/package.json
+++ b/packages/sd-jwt-vc/package.json
@@ -20,7 +20,11 @@
     "test:e2e": "vitest run ./test/*e2e.spec.ts --environment node",
     "test:cov": "vitest run --coverage"
   },
-  "keywords": ["sd-jwt", "sdjwt", "sd-jwt-vc"],
+  "keywords": [
+    "sd-jwt",
+    "sdjwt",
+    "sd-jwt-vc"
+  ],
   "engines": {
     "node": ">=18"
   },
@@ -35,22 +39,29 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "@sd-jwt/core": "workspace:*"
+    "@sd-jwt/core": "workspace:*",
+    "jwt-status-list": "^0.0.4"
   },
   "devDependencies": {
     "@sd-jwt/crypto-nodejs": "workspace:*",
-    "@sd-jwt/types": "workspace:*"
+    "@sd-jwt/types": "workspace:*",
+    "jose": "^5.2.2"
   },
   "publishConfig": {
     "access": "public"
   },
   "tsup": {
-    "entry": ["./src/index.ts"],
+    "entry": [
+      "./src/index.ts"
+    ],
     "sourceMap": true,
     "splitting": false,
     "clean": true,
     "dts": true,
-    "format": ["cjs", "esm"]
+    "format": [
+      "cjs",
+      "esm"
+    ]
   },
   "gitHead": "ded40e4551bde7ae93083181bf26bd1b38bbfcfb"
 }

--- a/packages/sd-jwt-vc/package.json
+++ b/packages/sd-jwt-vc/package.json
@@ -20,7 +20,11 @@
     "test:e2e": "vitest run ./test/*e2e.spec.ts --environment node",
     "test:cov": "vitest run --coverage"
   },
-  "keywords": ["sd-jwt", "sdjwt", "sd-jwt-vc"],
+  "keywords": [
+    "sd-jwt",
+    "sdjwt",
+    "sd-jwt-vc"
+  ],
   "engines": {
     "node": ">=18"
   },
@@ -36,7 +40,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@sd-jwt/core": "workspace:*",
-    "jwt-status-list": "^0.0.4"
+    "jwt-status-list": "^0.0.5"
   },
   "devDependencies": {
     "@sd-jwt/crypto-nodejs": "workspace:*",
@@ -47,12 +51,17 @@
     "access": "public"
   },
   "tsup": {
-    "entry": ["./src/index.ts"],
+    "entry": [
+      "./src/index.ts"
+    ],
     "sourceMap": true,
     "splitting": false,
     "clean": true,
     "dts": true,
-    "format": ["cjs", "esm"]
+    "format": [
+      "cjs",
+      "esm"
+    ]
   },
   "gitHead": "ded40e4551bde7ae93083181bf26bd1b38bbfcfb"
 }

--- a/packages/sd-jwt-vc/package.json
+++ b/packages/sd-jwt-vc/package.json
@@ -20,11 +20,7 @@
     "test:e2e": "vitest run ./test/*e2e.spec.ts --environment node",
     "test:cov": "vitest run --coverage"
   },
-  "keywords": [
-    "sd-jwt",
-    "sdjwt",
-    "sd-jwt-vc"
-  ],
+  "keywords": ["sd-jwt", "sdjwt", "sd-jwt-vc"],
   "engines": {
     "node": ">=18"
   },
@@ -51,17 +47,12 @@
     "access": "public"
   },
   "tsup": {
-    "entry": [
-      "./src/index.ts"
-    ],
+    "entry": ["./src/index.ts"],
     "sourceMap": true,
     "splitting": false,
     "clean": true,
     "dts": true,
-    "format": [
-      "cjs",
-      "esm"
-    ]
+    "format": ["cjs", "esm"]
   },
   "gitHead": "ded40e4551bde7ae93083181bf26bd1b38bbfcfb"
 }

--- a/packages/sd-jwt-vc/src/index.ts
+++ b/packages/sd-jwt-vc/src/index.ts
@@ -47,15 +47,26 @@ export class SDJwtVcInstance extends SDJwtInstance<SdJwtVcPayload> {
     }
   }
 
-  /**
-   * Fetches the status list from the uri.
-   * @param uri
-   * @returns compact JWT
-   */
-  private async statusListFetcher(uri: string): Promise<string> {
-    // according to the spec we assume according to the spec that the response is a compact JWT
-    return fetch(uri).then((res) => res.text());
+/**
+ * Fetches the status list from the uri with a timeout of 10 seconds.
+ * @param uri The URI to fetch from.
+ * @returns A promise that resolves to a compact JWT.
+ */
+private async statusListFetcher(uri: string): Promise<string> {
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), 10000);
+
+  try {
+    const response = await fetch(uri, { signal: controller.signal });
+    if (!response.ok) {
+      throw new Error(`Error fetching status list: ${response.status} ${await response.text()}`);
+    }
+
+    return response.text();
+  } finally {
+      clearTimeout(timeoutId);
   }
+}
 
   /**
    * Validates the status, throws an error if the status is not 0.

--- a/packages/sd-jwt-vc/src/index.ts
+++ b/packages/sd-jwt-vc/src/index.ts
@@ -2,14 +2,22 @@ import { SDJwtInstance } from '@sd-jwt/core';
 import type { DisclosureFrame } from '@sd-jwt/types';
 import { SDJWTException } from '../../utils/dist';
 import type { SdJwtVcPayload } from './sd-jwt-vc-payload';
-
-export { SdJwtVcPayload } from './sd-jwt-vc-payload';
-
+import { getListFromStatusListJWT } from 'jwt-status-list';
+import type { SDJWTVCConfig } from './sd-jwt-vc-config';
 export class SDJwtVcInstance extends SDJwtInstance<SdJwtVcPayload> {
   /**
    * The type of the SD-JWT-VC set in the header.typ field.
    */
   protected type = 'vc+sd-jwt';
+
+  protected userConfig: SDJWTVCConfig = {};
+
+  constructor(userConfig?: SDJWTVCConfig) {
+    super(userConfig);
+    if (userConfig) {
+      this.userConfig = userConfig;
+    }
+  }
 
   /**
    * Validates if the disclosureFrame contains any reserved fields. If so it will throw an error.
@@ -33,5 +41,48 @@ export class SDJwtVcInstance extends SDJwtInstance<SdJwtVcPayload> {
         throw new SDJWTException('Cannot disclose protected field');
       }
     }
+  }
+
+  /**
+   * Verifies the SD-JWT-VC.
+   */
+  async verify(
+    encodedSDJwt: string,
+    requiredClaimKeys?: string[],
+    requireKeyBindings?: boolean,
+  ) {
+    // Call the parent class's verify method
+    const result = await super
+      .verify(encodedSDJwt, requiredClaimKeys, requireKeyBindings)
+      .then((res) => {
+        return { payload: res.payload as SdJwtVcPayload, header: res.header };
+      });
+
+    if (result.payload.status) {
+      //checks if a status field is present in the payload based on https://www.ietf.org/archive/id/draft-ietf-oauth-status-list-02.html
+      if (result.payload.status.status_list) {
+        // fetch the status list from the uri
+        result.payload.status.status_list.uri;
+        if (!this.userConfig.statusListFetcher) {
+          throw new SDJWTException('Status list fetcher not found');
+        }
+        // fetch the status list from the uri
+        const statusListJWT = await this.userConfig.statusListFetcher(
+          result.payload.status.status_list.uri,
+        );
+        // get the status list from the status list JWT
+        const statusList = getListFromStatusListJWT(statusListJWT);
+        const status = statusList.getStatus(
+          result.payload.status.status_list.idx,
+        );
+        // validate the status
+        if (!this.userConfig.statusValidator) {
+          throw new SDJWTException('Status validator not found');
+        }
+        await this.userConfig.statusValidator(status);
+      }
+    }
+
+    return result;
   }
 }

--- a/packages/sd-jwt-vc/src/index.ts
+++ b/packages/sd-jwt-vc/src/index.ts
@@ -47,26 +47,30 @@ export class SDJwtVcInstance extends SDJwtInstance<SdJwtVcPayload> {
     }
   }
 
-/**
- * Fetches the status list from the uri with a timeout of 10 seconds.
- * @param uri The URI to fetch from.
- * @returns A promise that resolves to a compact JWT.
- */
-private async statusListFetcher(uri: string): Promise<string> {
-  const controller = new AbortController();
-  const timeoutId = setTimeout(() => controller.abort(), 10000);
+  /**
+   * Fetches the status list from the uri with a timeout of 10 seconds.
+   * @param uri The URI to fetch from.
+   * @returns A promise that resolves to a compact JWT.
+   */
+  private async statusListFetcher(uri: string): Promise<string> {
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), 10000);
 
-  try {
-    const response = await fetch(uri, { signal: controller.signal });
-    if (!response.ok) {
-      throw new Error(`Error fetching status list: ${response.status} ${await response.text()}`);
-    }
+    try {
+      const response = await fetch(uri, { signal: controller.signal });
+      if (!response.ok) {
+        throw new Error(
+          `Error fetching status list: ${
+            response.status
+          } ${await response.text()}`,
+        );
+      }
 
-    return response.text();
-  } finally {
+      return response.text();
+    } finally {
       clearTimeout(timeoutId);
+    }
   }
-}
 
   /**
    * Validates the status, throws an error if the status is not 0.

--- a/packages/sd-jwt-vc/src/index.ts
+++ b/packages/sd-jwt-vc/src/index.ts
@@ -101,7 +101,6 @@ export class SDJwtVcInstance extends SDJwtInstance<SdJwtVcPayload> {
       //checks if a status field is present in the payload based on https://www.ietf.org/archive/id/draft-ietf-oauth-status-list-02.html
       if (result.payload.status.status_list) {
         // fetch the status list from the uri
-        result.payload.status.status_list.uri;
         const fetcher =
           this.userConfig.statusListFetcher ?? this.statusListFetcher;
         // fetch the status list from the uri

--- a/packages/sd-jwt-vc/src/index.ts
+++ b/packages/sd-jwt-vc/src/index.ts
@@ -2,7 +2,7 @@ import { SDJwtInstance } from '@sd-jwt/core';
 import type { DisclosureFrame } from '@sd-jwt/types';
 import { SDJWTException } from '../../utils/dist';
 import type { SdJwtVcPayload } from './sd-jwt-vc-payload';
-import { getListFromStatusListJWT } from 'jwt-status-list';
+import { getListFromStatusListJWT } from '@sd-jwt/jwt-status-list';
 import type { SDJWTVCConfig } from './sd-jwt-vc-config';
 export class SDJwtVcInstance extends SDJwtInstance<SdJwtVcPayload> {
   /**

--- a/packages/sd-jwt-vc/src/sd-jwt-vc-config.ts
+++ b/packages/sd-jwt-vc/src/sd-jwt-vc-config.ts
@@ -1,0 +1,11 @@
+import type { SDJWTConfig } from '@sd-jwt/types';
+
+/**
+ * Configuration for SD-JWT-VC
+ */
+export type SDJWTVCConfig = SDJWTConfig & {
+  // A function that fetches the status list from the uri. It should also verify the status list JWT before returning the jwt.
+  statusListFetcher?: (uri: string) => Promise<string>;
+  // validte the status and decide if the status is valid or not. If the status is not valid, it should throw an error.
+  statusValidator?: (status: number) => Promise<void>;
+};

--- a/packages/sd-jwt-vc/src/sd-jwt-vc-config.ts
+++ b/packages/sd-jwt-vc/src/sd-jwt-vc-config.ts
@@ -4,8 +4,8 @@ import type { SDJWTConfig } from '@sd-jwt/types';
  * Configuration for SD-JWT-VC
  */
 export type SDJWTVCConfig = SDJWTConfig & {
-  // A function that fetches the status list from the uri. It should also verify the status list JWT before returning the jwt.
+  // A function that fetches the status list from the uri. If not provided, the library will assume that the response is a compact JWT.
   statusListFetcher?: (uri: string) => Promise<string>;
-  // validte the status and decide if the status is valid or not. If the status is not valid, it should throw an error.
+  // validte the status and decide if the status is valid or not. If not provided, the code will continue if it is 0, otherwise it will throw an error.
   statusValidator?: (status: number) => Promise<void>;
 };

--- a/packages/sd-jwt-vc/src/sd-jwt-vc-payload.ts
+++ b/packages/sd-jwt-vc/src/sd-jwt-vc-payload.ts
@@ -1,4 +1,5 @@
 import type { SdJwtPayload } from '@sd-jwt/core';
+import type { SDJWTVCStatusReference } from './sd-jwt-vc-status-reference';
 
 export interface SdJwtVcPayload extends SdJwtPayload {
   // REQUIRED. The Issuer of the Verifiable Credential. The value of iss MUST be a URI. See [RFC7519] for more information.
@@ -11,9 +12,8 @@ export interface SdJwtVcPayload extends SdJwtPayload {
   cnf?: unknown;
   // REQUIRED. The type of the Verifiable Credential, e.g., https://credentials.example.com/identity_credential, as defined in Section 3.2.2.1.1.
   vct: string;
-  // OPTIONAL. The information on how to read the status of the Verifiable Credential. See [I-D.looker-oauth-jwt-cwt-status-list] for more information.
-  status?: unknown;
-
+  // OPTIONAL. The information on how to read the status of the Verifiable Credential. See [https://www.ietf.org/archive/id/draft-ietf-oauth-status-list-02.html] for more information.
+  status?: SDJWTVCStatusReference;
   // OPTIONAL. The identifier of the Subject of the Verifiable Credential. The Issuer MAY use it to provide the Subject identifier known by the Issuer. There is no requirement for a binding to exist between sub and cnf claims.
   sub?: string;
   // OPTIONAL. The time of issuance of the Verifiable Credential. See [RFC7519] for more information.

--- a/packages/sd-jwt-vc/src/sd-jwt-vc-status-reference.ts
+++ b/packages/sd-jwt-vc/src/sd-jwt-vc-status-reference.ts
@@ -1,0 +1,9 @@
+export interface SDJWTVCStatusReference {
+  // REQUIRED. implenentation according to https://www.ietf.org/archive/id/draft-ietf-oauth-status-list-02.html
+  status_list: {
+    // REQUIRED. index in the list of statuses
+    idx: number;
+    // REQUIRED. the reference to fetch the status list
+    uri: string;
+  };
+}

--- a/packages/sd-jwt-vc/src/test/index.spec.ts
+++ b/packages/sd-jwt-vc/src/test/index.spec.ts
@@ -1,16 +1,16 @@
 import { digest, generateSalt } from '@sd-jwt/crypto-nodejs';
 import type {
   DisclosureFrame,
-  JwtPayload,
   Signer,
   Verifier,
+  JwtPayload,
 } from '@sd-jwt/types';
 import { describe, test, expect } from 'vitest';
 import { SDJwtVcInstance } from '..';
 import type { SdJwtVcPayload } from '../sd-jwt-vc-payload';
 import Crypto from 'node:crypto';
-import { StatusList, createUnsignedJWT } from 'jwt-status-list';
-import type { JWTHeaderParameters } from 'jose';
+import { StatusList, createHeaderAndPayload } from '@sd-jwt/jwt-status-list';
+import { SignJWT, type JWTHeaderParameters } from 'jose';
 
 const iss = 'ExampleIssuer';
 const vct = 'https://example.com/schema/1';
@@ -44,7 +44,10 @@ const generateStatusList = (): Promise<string> => {
   const header: JWTHeaderParameters = {
     alg: 'EdDSA',
   };
-  return createUnsignedJWT(statusList, payload, header).sign(privateKey);
+  const values = createHeaderAndPayload(statusList, payload, header);
+  return new SignJWT(values.payload)
+    .setProtectedHeader(values.header)
+    .sign(privateKey);
 };
 
 const statusListJWT = await generateStatusList();

--- a/packages/sd-jwt-vc/src/test/index.spec.ts
+++ b/packages/sd-jwt-vc/src/test/index.spec.ts
@@ -9,8 +9,12 @@ import { describe, test, expect } from 'vitest';
 import { SDJwtVcInstance } from '..';
 import type { SdJwtVcPayload } from '../sd-jwt-vc-payload';
 import Crypto from 'node:crypto';
-import { StatusList, createHeaderAndPayload } from '@sd-jwt/jwt-status-list';
-import { SignJWT, type JWTHeaderParameters } from 'jose';
+import {
+  StatusList,
+  type StatusListJWTHeaderParameters,
+  createHeaderAndPayload,
+} from '@sd-jwt/jwt-status-list';
+import { SignJWT } from 'jose';
 
 const iss = 'ExampleIssuer';
 const vct = 'https://example.com/schema/1';
@@ -40,8 +44,9 @@ const generateStatusList = async (): Promise<string> => {
     sub: 'https://example.com/status/1',
     iat: new Date().getTime() / 1000,
   };
-  const header: JWTHeaderParameters = {
+  const header: StatusListJWTHeaderParameters = {
     alg: 'EdDSA',
+    typ: 'statuslist+jwt',
   };
   const values = createHeaderAndPayload(statusList, payload, header);
   return new SignJWT(values.payload)

--- a/packages/sd-jwt-vc/src/test/index.spec.ts
+++ b/packages/sd-jwt-vc/src/test/index.spec.ts
@@ -10,7 +10,7 @@ import { SDJwtVcInstance } from '..';
 import type { SdJwtVcPayload } from '../sd-jwt-vc-payload';
 import Crypto from 'node:crypto';
 import { StatusList, createHeaderAndPayload } from '@sd-jwt/jwt-status-list';
-import { SignJWT, exportJWK, jwtVerify, type JWTHeaderParameters } from 'jose';
+import { SignJWT, type JWTHeaderParameters } from 'jose';
 
 const iss = 'ExampleIssuer';
 const vct = 'https://example.com/schema/1';

--- a/packages/types/src/type.ts
+++ b/packages/types/src/type.ts
@@ -66,6 +66,7 @@ export interface JwtPayload {
   cnf?: {
     jwk: JsonWebKey;
   };
+  exp?: number;
   [key: string]: unknown;
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,7 +16,7 @@ importers:
         version: 20.12.7
       '@vitest/coverage-v8':
         specifier: ^1.2.2
-        version: 1.5.1(vitest@1.5.1)
+        version: 1.5.1(vitest@1.5.1(@types/node@20.12.7)(jsdom@24.0.0))
       husky:
         specifier: ^9.0.11
         version: 9.0.11
@@ -28,13 +28,13 @@ importers:
         version: 24.0.0
       lerna:
         specifier: ^8.1.2
-        version: 8.1.2
+        version: 8.1.2(encoding@0.1.13)
       ts-node:
         specifier: ^10.9.1
         version: 10.9.2(@types/node@20.12.7)(typescript@5.4.5)
       tsup:
         specifier: ^8.0.2
-        version: 8.0.2(ts-node@10.9.2)(typescript@5.4.5)
+        version: 8.0.2(postcss@8.4.38)(ts-node@10.9.2(@types/node@20.12.7)(typescript@5.4.5))(typescript@5.4.5)
       typescript:
         specifier: ^5.3.2
         version: 5.4.5
@@ -206,6 +206,9 @@ importers:
       '@sd-jwt/core':
         specifier: workspace:*
         version: link:../core
+      jwt-status-list:
+        specifier: ^0.0.4
+        version: 0.0.4
     devDependencies:
       '@sd-jwt/crypto-nodejs':
         specifier: workspace:*
@@ -213,6 +216,9 @@ importers:
       '@sd-jwt/types':
         specifier: workspace:*
         version: link:../types
+      jose:
+        specifier: ^5.2.2
+        version: 5.2.4
 
   packages/types: {}
 
@@ -1212,6 +1218,10 @@ packages:
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
 
+  base64url@3.0.1:
+    resolution: {integrity: sha512-ir1UPr3dkwexU7FdV8qBBbNDRUhMmIekYMFZfi+C/sLNnRESKPl23nB9b2pltqfOQNnGzsDdId90AEtG5tCx4A==}
+    engines: {node: '>=6.0.0'}
+
   before-after-hook@2.2.3:
     resolution: {integrity: sha512-NzUnlZexiaH/46WDhANlyR2bXRopNg4F/zuSA3OpZnllCUgRaOF2znDioDWrmbNVsuZk6l9pMquQB38cfBZwkQ==}
 
@@ -2127,6 +2137,10 @@ packages:
     resolution: {integrity: sha512-POQXvpdL69+CluYsillJ7SUhKvytYjW9vG/GKpnf+xP8UWgYEM/RaMzHHofbALDiKbbP1W8UEYmgGl39WkPZsg==}
     engines: {'0': node >= 0.2.0}
 
+  jwt-status-list@0.0.4:
+    resolution: {integrity: sha512-HBCemEniNt6vdk39840ERHtnO81fM6zYXQ5EEga6aUZitEOGbXipqf6OODkBrrbpaS0UFpFfpFBb4IlSMHRnBg==}
+    engines: {node: '>=18.0.0'}
+
   kind-of@6.0.3:
     resolution: {integrity: sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==}
     engines: {node: '>=0.10.0'}
@@ -2603,6 +2617,9 @@ packages:
     resolution: {integrity: sha512-cJKrW21VRE8vVTRskJo78c/RCvwJCn1f4qgfxL4w77SOWrTCRcmfkYHlHtS0gqpgjv3zhXflRtgsrUCX5xwNnQ==}
     engines: {node: ^16.14.0 || >=18.0.0}
     hasBin: true
+
+  pako@2.1.0:
+    resolution: {integrity: sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug==}
 
   parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
@@ -3766,12 +3783,12 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.1
       '@jridgewell/sourcemap-codec': 1.4.15
 
-  '@lerna/create@8.1.2(typescript@5.4.5)':
+  '@lerna/create@8.1.2(encoding@0.1.13)(typescript@5.4.5)':
     dependencies:
       '@npmcli/run-script': 7.0.2
       '@nx/devkit': 18.0.4(nx@18.0.4)
       '@octokit/plugin-enterprise-rest': 6.0.1
-      '@octokit/rest': 19.0.11
+      '@octokit/rest': 19.0.11(encoding@0.1.13)
       byte-size: 8.1.1
       chalk: 4.1.0
       clone-deep: 4.0.1
@@ -3801,7 +3818,7 @@ snapshots:
       make-dir: 4.0.0
       minimatch: 3.0.5
       multimatch: 5.0.0
-      node-fetch: 2.6.7
+      node-fetch: 2.6.7(encoding@0.1.13)
       npm-package-arg: 8.1.1
       npm-packlist: 5.1.1
       npm-registry-fetch: 14.0.5
@@ -3962,11 +3979,11 @@ snapshots:
 
   '@octokit/auth-token@3.0.4': {}
 
-  '@octokit/core@4.2.4':
+  '@octokit/core@4.2.4(encoding@0.1.13)':
     dependencies:
       '@octokit/auth-token': 3.0.4
-      '@octokit/graphql': 5.0.6
-      '@octokit/request': 6.2.8
+      '@octokit/graphql': 5.0.6(encoding@0.1.13)
+      '@octokit/request': 6.2.8(encoding@0.1.13)
       '@octokit/request-error': 3.0.3
       '@octokit/types': 9.3.2
       before-after-hook: 2.2.3
@@ -3980,9 +3997,9 @@ snapshots:
       is-plain-object: 5.0.0
       universal-user-agent: 6.0.1
 
-  '@octokit/graphql@5.0.6':
+  '@octokit/graphql@5.0.6(encoding@0.1.13)':
     dependencies:
-      '@octokit/request': 6.2.8
+      '@octokit/request': 6.2.8(encoding@0.1.13)
       '@octokit/types': 9.3.2
       universal-user-agent: 6.0.1
     transitivePeerDependencies:
@@ -3992,19 +4009,19 @@ snapshots:
 
   '@octokit/plugin-enterprise-rest@6.0.1': {}
 
-  '@octokit/plugin-paginate-rest@6.1.2(@octokit/core@4.2.4)':
+  '@octokit/plugin-paginate-rest@6.1.2(@octokit/core@4.2.4(encoding@0.1.13))':
     dependencies:
-      '@octokit/core': 4.2.4
+      '@octokit/core': 4.2.4(encoding@0.1.13)
       '@octokit/tsconfig': 1.0.2
       '@octokit/types': 9.3.2
 
-  '@octokit/plugin-request-log@1.0.4(@octokit/core@4.2.4)':
+  '@octokit/plugin-request-log@1.0.4(@octokit/core@4.2.4(encoding@0.1.13))':
     dependencies:
-      '@octokit/core': 4.2.4
+      '@octokit/core': 4.2.4(encoding@0.1.13)
 
-  '@octokit/plugin-rest-endpoint-methods@7.2.3(@octokit/core@4.2.4)':
+  '@octokit/plugin-rest-endpoint-methods@7.2.3(@octokit/core@4.2.4(encoding@0.1.13))':
     dependencies:
-      '@octokit/core': 4.2.4
+      '@octokit/core': 4.2.4(encoding@0.1.13)
       '@octokit/types': 10.0.0
 
   '@octokit/request-error@3.0.3':
@@ -4013,23 +4030,23 @@ snapshots:
       deprecation: 2.3.1
       once: 1.4.0
 
-  '@octokit/request@6.2.8':
+  '@octokit/request@6.2.8(encoding@0.1.13)':
     dependencies:
       '@octokit/endpoint': 7.0.6
       '@octokit/request-error': 3.0.3
       '@octokit/types': 9.3.2
       is-plain-object: 5.0.0
-      node-fetch: 2.6.7
+      node-fetch: 2.6.7(encoding@0.1.13)
       universal-user-agent: 6.0.1
     transitivePeerDependencies:
       - encoding
 
-  '@octokit/rest@19.0.11':
+  '@octokit/rest@19.0.11(encoding@0.1.13)':
     dependencies:
-      '@octokit/core': 4.2.4
-      '@octokit/plugin-paginate-rest': 6.1.2(@octokit/core@4.2.4)
-      '@octokit/plugin-request-log': 1.0.4(@octokit/core@4.2.4)
-      '@octokit/plugin-rest-endpoint-methods': 7.2.3(@octokit/core@4.2.4)
+      '@octokit/core': 4.2.4(encoding@0.1.13)
+      '@octokit/plugin-paginate-rest': 6.1.2(@octokit/core@4.2.4(encoding@0.1.13))
+      '@octokit/plugin-request-log': 1.0.4(@octokit/core@4.2.4(encoding@0.1.13))
+      '@octokit/plugin-rest-endpoint-methods': 7.2.3(@octokit/core@4.2.4(encoding@0.1.13))
     transitivePeerDependencies:
       - encoding
 
@@ -4227,7 +4244,7 @@ snapshots:
 
   '@types/normalize-package-data@2.4.4': {}
 
-  '@vitest/coverage-v8@1.5.1(vitest@1.5.1)':
+  '@vitest/coverage-v8@1.5.1(vitest@1.5.1(@types/node@20.12.7)(jsdom@24.0.0))':
     dependencies:
       '@ampproject/remapping': 2.2.1
       '@bcoe/v8-coverage': 0.2.3
@@ -4391,6 +4408,8 @@ snapshots:
   balanced-match@1.0.2: {}
 
   base64-js@1.5.1: {}
+
+  base64url@3.0.1: {}
 
   before-after-hook@2.2.3: {}
 
@@ -4660,6 +4679,7 @@ snapshots:
       js-yaml: 4.1.0
       parse-json: 5.2.0
       path-type: 4.0.0
+    optionalDependencies:
       typescript: 5.4.5
 
   create-require@1.1.1: {}
@@ -5400,15 +5420,21 @@ snapshots:
 
   jsonparse@1.3.1: {}
 
+  jwt-status-list@0.0.4:
+    dependencies:
+      base64url: 3.0.1
+      jose: 5.2.4
+      pako: 2.1.0
+
   kind-of@6.0.3: {}
 
-  lerna@8.1.2:
+  lerna@8.1.2(encoding@0.1.13):
     dependencies:
-      '@lerna/create': 8.1.2(typescript@5.4.5)
+      '@lerna/create': 8.1.2(encoding@0.1.13)(typescript@5.4.5)
       '@npmcli/run-script': 7.0.2
       '@nx/devkit': 18.0.4(nx@18.0.4)
       '@octokit/plugin-enterprise-rest': 6.0.1
-      '@octokit/rest': 19.0.11
+      '@octokit/rest': 19.0.11(encoding@0.1.13)
       byte-size: 8.1.1
       chalk: 4.1.0
       clone-deep: 4.0.1
@@ -5444,7 +5470,7 @@ snapshots:
       make-dir: 4.0.0
       minimatch: 3.0.5
       multimatch: 5.0.0
-      node-fetch: 2.6.7
+      node-fetch: 2.6.7(encoding@0.1.13)
       npm-package-arg: 8.1.1
       npm-packlist: 5.1.1
       npm-registry-fetch: 14.0.5
@@ -5774,9 +5800,11 @@ snapshots:
 
   neo-async@2.6.2: {}
 
-  node-fetch@2.6.7:
+  node-fetch@2.6.7(encoding@0.1.13):
     dependencies:
       whatwg-url: 5.0.0
+    optionalDependencies:
+      encoding: 0.1.13
 
   node-gyp@10.0.1:
     dependencies:
@@ -6092,6 +6120,8 @@ snapshots:
       - bluebird
       - supports-color
 
+  pako@2.1.0: {}
+
   parent-module@1.0.1:
     dependencies:
       callsites: 3.1.0
@@ -6171,11 +6201,13 @@ snapshots:
       mlly: 1.5.0
       pathe: 1.1.2
 
-  postcss-load-config@4.0.2(ts-node@10.9.2):
+  postcss-load-config@4.0.2(postcss@8.4.38)(ts-node@10.9.2(@types/node@20.12.7)(typescript@5.4.5)):
     dependencies:
       lilconfig: 3.0.0
-      ts-node: 10.9.2(@types/node@20.12.7)(typescript@5.4.5)
       yaml: 2.3.4
+    optionalDependencies:
+      postcss: 8.4.38
+      ts-node: 10.9.2(@types/node@20.12.7)(typescript@5.4.5)
 
   postcss@8.4.38:
     dependencies:
@@ -6730,7 +6762,7 @@ snapshots:
 
   tslib@2.6.2: {}
 
-  tsup@8.0.2(ts-node@10.9.2)(typescript@5.4.5):
+  tsup@8.0.2(postcss@8.4.38)(ts-node@10.9.2(@types/node@20.12.7)(typescript@5.4.5))(typescript@5.4.5):
     dependencies:
       bundle-require: 4.0.2(esbuild@0.19.12)
       cac: 6.7.14
@@ -6740,12 +6772,14 @@ snapshots:
       execa: 5.1.1
       globby: 11.1.0
       joycon: 3.1.1
-      postcss-load-config: 4.0.2(ts-node@10.9.2)
+      postcss-load-config: 4.0.2(postcss@8.4.38)(ts-node@10.9.2(@types/node@20.12.7)(typescript@5.4.5))
       resolve-from: 5.0.0
       rollup: 4.10.0
       source-map: 0.8.0-beta.0
       sucrase: 3.35.0
       tree-kill: 1.2.2
+    optionalDependencies:
+      postcss: 8.4.38
       typescript: 5.4.5
     transitivePeerDependencies:
       - supports-color
@@ -6851,16 +6885,15 @@ snapshots:
 
   vite@5.2.10(@types/node@20.12.7):
     dependencies:
-      '@types/node': 20.12.7
       esbuild: 0.20.2
       postcss: 8.4.38
       rollup: 4.14.0
     optionalDependencies:
+      '@types/node': 20.12.7
       fsevents: 2.3.3
 
   vitest@1.5.1(@types/node@20.12.7)(jsdom@24.0.0):
     dependencies:
-      '@types/node': 20.12.7
       '@vitest/expect': 1.5.1
       '@vitest/runner': 1.5.1
       '@vitest/snapshot': 1.5.1
@@ -6870,7 +6903,6 @@ snapshots:
       chai: 4.4.1
       debug: 4.3.4
       execa: 8.0.1
-      jsdom: 24.0.0
       local-pkg: 0.5.0
       magic-string: 0.30.7
       pathe: 1.1.2
@@ -6882,6 +6914,9 @@ snapshots:
       vite: 5.2.10(@types/node@20.12.7)
       vite-node: 1.5.1(@types/node@20.12.7)
       why-is-node-running: 2.2.2
+    optionalDependencies:
+      '@types/node': 20.12.7
+      jsdom: 24.0.0
     transitivePeerDependencies:
       - less
       - lightningcss

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -183,6 +183,22 @@ importers:
         specifier: workspace:*
         version: link:../node-crypto
 
+  packages/jwt-status-list:
+    dependencies:
+      base64url:
+        specifier: ^3.0.1
+        version: 3.0.1
+      pako:
+        specifier: ^2.1.0
+        version: 2.1.0
+    devDependencies:
+      '@types/pako':
+        specifier: ^2.0.3
+        version: 2.0.3
+      jose:
+        specifier: ^5.2.2
+        version: 5.2.4
+
   packages/node-crypto: {}
 
   packages/present:
@@ -206,9 +222,9 @@ importers:
       '@sd-jwt/core':
         specifier: workspace:*
         version: link:../core
-      jwt-status-list:
-        specifier: ^0.0.5
-        version: 0.0.5
+      '@sd-jwt/jwt-status-list':
+        specifier: workspace:*
+        version: link:../jwt-status-list
     devDependencies:
       '@sd-jwt/crypto-nodejs':
         specifier: workspace:*
@@ -1058,6 +1074,9 @@ packages:
 
   '@types/normalize-package-data@2.4.4':
     resolution: {integrity: sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==}
+
+  '@types/pako@2.0.3':
+    resolution: {integrity: sha512-bq0hMV9opAcrmE0Byyo0fY3Ew4tgOevJmQ9grUhpXQhYfyLJ1Kqg3P33JT5fdbT2AjeAjR51zqqVjAL/HMkx7Q==}
 
   '@vitest/coverage-v8@1.5.1':
     resolution: {integrity: sha512-Zx+dYEDcZg+44ksjIWvWosIGlPLJB1PPpN3O8+Xrh/1qa7WSFA6Y8H7lsZJTYrxu4G2unk9tvP5TgjIGDliF1w==}
@@ -2136,10 +2155,6 @@ packages:
   jsonparse@1.3.1:
     resolution: {integrity: sha512-POQXvpdL69+CluYsillJ7SUhKvytYjW9vG/GKpnf+xP8UWgYEM/RaMzHHofbALDiKbbP1W8UEYmgGl39WkPZsg==}
     engines: {'0': node >= 0.2.0}
-
-  jwt-status-list@0.0.5:
-    resolution: {integrity: sha512-vmcRQsUpk9v6/+GGGzxJN0+ylUd4b1pUQuD9RyonaQrOxBUzB9R4HpQ4Tlv5RY4u46VZX3HvKaaoClpU9OfdTQ==}
-    engines: {node: '>=18.0.0'}
 
   kind-of@6.0.3:
     resolution: {integrity: sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==}
@@ -4244,6 +4259,8 @@ snapshots:
 
   '@types/normalize-package-data@2.4.4': {}
 
+  '@types/pako@2.0.3': {}
+
   '@vitest/coverage-v8@1.5.1(vitest@1.5.1(@types/node@20.12.7)(jsdom@24.0.0))':
     dependencies:
       '@ampproject/remapping': 2.2.1
@@ -5419,11 +5436,6 @@ snapshots:
       graceful-fs: 4.2.11
 
   jsonparse@1.3.1: {}
-
-  jwt-status-list@0.0.5:
-    dependencies:
-      base64url: 3.0.1
-      pako: 2.1.0
 
   kind-of@6.0.3: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -185,6 +185,9 @@ importers:
 
   packages/jwt-status-list:
     dependencies:
+      '@sd-jwt/types':
+        specifier: workspace:*
+        version: link:../types
       base64url:
         specifier: ^3.0.1
         version: 3.0.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -207,8 +207,8 @@ importers:
         specifier: workspace:*
         version: link:../core
       jwt-status-list:
-        specifier: ^0.0.4
-        version: 0.0.4
+        specifier: ^0.0.5
+        version: 0.0.5
     devDependencies:
       '@sd-jwt/crypto-nodejs':
         specifier: workspace:*
@@ -2137,8 +2137,8 @@ packages:
     resolution: {integrity: sha512-POQXvpdL69+CluYsillJ7SUhKvytYjW9vG/GKpnf+xP8UWgYEM/RaMzHHofbALDiKbbP1W8UEYmgGl39WkPZsg==}
     engines: {'0': node >= 0.2.0}
 
-  jwt-status-list@0.0.4:
-    resolution: {integrity: sha512-HBCemEniNt6vdk39840ERHtnO81fM6zYXQ5EEga6aUZitEOGbXipqf6OODkBrrbpaS0UFpFfpFBb4IlSMHRnBg==}
+  jwt-status-list@0.0.5:
+    resolution: {integrity: sha512-vmcRQsUpk9v6/+GGGzxJN0+ylUd4b1pUQuD9RyonaQrOxBUzB9R4HpQ4Tlv5RY4u46VZX3HvKaaoClpU9OfdTQ==}
     engines: {node: '>=18.0.0'}
 
   kind-of@6.0.3:
@@ -5420,10 +5420,9 @@ snapshots:
 
   jsonparse@1.3.1: {}
 
-  jwt-status-list@0.0.4:
+  jwt-status-list@0.0.5:
     dependencies:
       base64url: 3.0.1
-      jose: 5.2.4
       pako: 2.1.0
 
   kind-of@6.0.3: {}


### PR DESCRIPTION
closes #224 

I extended the verify method so all checked that should be done via sd-jwt are called and then we are looking for revocation.

We will only check the revocation if the `status` field is present. We are not throwing an error if somebody has referenced another status mechanism and we are not validating if the status field was correctly placed inside the payload when the credential is created (but types are provided).

The verifier has to implement the fetch and validation function of the jwt-status-token and also the logic how to deal with the status (it can have multiple definitions but the values are not covered by the spec).

The statusValidator function is to stop the current validation. In case the status has a value to continue, the function executes without throwing an error and the verifier has to deal with the state after the successful verification.