### PR TITLE
fix: check if the header includes the string

### DIFF
--- a/packages/sd-jwt-vc/src/sd-jwt-vc-instance.ts
+++ b/packages/sd-jwt-vc/src/sd-jwt-vc-instance.ts
@@ -71,7 +71,9 @@ export class SDJwtVcInstance extends SDJwtInstance<SdJwtVcPayload> {
 
       // according to the spec the content type should be application/statuslist+jwt
       if (
-        response.headers.get('content-type') !== 'application/statuslist+jwt'
+        !response.headers
+          .get('content-type')
+          ?.includes('application/statuslist+jwt')
       ) {
         throw new Error('Invalid content type');
       }


### PR DESCRIPTION
Before we checked for equal, ignoring that the charset will be added. Using include solves this problem

Signed-off-by: Mirko Mollik <mirkomollik@gmail.com>