### PR TITLE
fix: also push tags when releasing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -189,4 +189,4 @@ jobs:
           pnpm format
           git add .
           git commit -m "chore: format generated files"
-          git push origin HEAD:main          
+          git push origin HEAD:main --tags


### PR DESCRIPTION
This fix should also push the tags that are required for a new release to github

Signed-off-by: Mirko Mollik <mirkomollik@gmail.com>